### PR TITLE
MLXPK-1499 Allow the user to choose the interval that validation is performed

### DIFF
--- a/src/ng_model_gym/nss/configs/default.json
+++ b/src/ng_model_gym/nss/configs/default.json
@@ -29,6 +29,7 @@
         "scale": 2.0,
         "seed": 123456,
         "perform_validate": true,
+        "validate_frequency": 1,
         "finetune": false,
         "resume": false,
         "pretrained_weights": null,

--- a/src/ng_model_gym/nss/configs/schema_config.json
+++ b/src/ng_model_gym/nss/configs/schema_config.json
@@ -157,8 +157,23 @@
             "description": "Path to the weights of the pretrained model"
         },
         "perform_validate": {
-            "description": "Perform validation at the end of each training epoch",
+            "description": "Perform validation at the end of specific training epochs, as set by the validate_frequency field.",
             "type": "boolean"
+        },
+        "validate_frequency": {
+            "anyOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "items": {
+                        "type": "integer"
+                    },
+                    "type": "array"
+                }
+            ],
+            "default": 1,
+            "description": "For a single int, N, validate every N epochs. For a List of ints, run validation after each epoch in the List."
         },
         "fp32": {
             "number_of_epochs": {

--- a/src/ng_model_gym/trainer.py
+++ b/src/ng_model_gym/trainer.py
@@ -294,8 +294,18 @@ class Trainer:
             save_frequency = int(self.training_mode_params.checkpoints.save_frequency)
             self._save_checkpoint(save_frequency, epoch, total_epochs)
 
-            # Evaluate on the validation set.
-            if self.params.train.perform_validate:
+            # Evaluate on the validation set, depending on the epoch number
+            validate_frequency = self.params.train.validate_frequency
+            if self.params.train.perform_validate and (
+                (
+                    isinstance(validate_frequency, int)
+                    and epoch % validate_frequency == 0
+                )
+                or (
+                    isinstance(validate_frequency, (list))
+                    and epoch in validate_frequency
+                )
+            ):
                 with torch.no_grad():
                     self.validate(epoch)
 

--- a/src/ng_model_gym/utils/config_model.py
+++ b/src/ng_model_gym/utils/config_model.py
@@ -2,7 +2,7 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
-from typing import Optional
+from typing import List, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -171,7 +171,11 @@ class Train(PydanticConfigModel):
         description="Path to the weights of the pretrained model"
     )
     perform_validate: bool = Field(
-        description="Perform validation at the end of each training epoch"
+        description="Perform validation at the end of specific training epochs, as set by the validate_frequency field."
+    )
+    validate_frequency: Union[int, List[int]] = Field(
+        default=1,
+        description="For a single int, N, validate every N epochs. For a List of ints, run validation after each epoch in the List.",
     )
     fp32: TrainingConfig
     qat: TrainingConfig

--- a/tests/nss/integration/base_integration.py
+++ b/tests/nss/integration/base_integration.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 from importlib.resources import files
 from pathlib import Path
+from typing import List
 
 import torch
 
@@ -69,7 +70,7 @@ class BaseIntegrationTest(unittest.TestCase):
         """Clean up the temporary directory."""
         shutil.rmtree(self.test_dir)
 
-    def check_log(self, msgs):
+    def check_log(self, msgs: List):
         """Verify that the log file contents matches the log."""
         log_file_path = Path(self.model_out_dir, "output.log")
         with open(log_file_path, "r", encoding="utf-8") as file:


### PR DESCRIPTION
Config accepts single integer or list of integers for after which epochs to perform validation.
In the case of single integer, N, we validate every N epochs. In the case of a list of integers, we validate after the epoch pertaining to each of these values.

Signed-off-by: James Ward <james.ward@arm.com>
Change-Id: I6b1387d9856ef47b493ed3c9288dc4899b174da5
