### PR TITLE
Fix default path in generate_config_schema.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ checkpoints/*
 *.pt
 !tests/nss/unit/data/nss_v1_golden_values/*.pt
 *.safetensors
+
+# These two files are generated if the user runs `init`
 config.json
 schema_config.json
+
+# We do want to keep the default config file in source control
 !src/ng_model_gym/usecases/nss/configs/schema_config.json

--- a/scripts/generate_config_schema.py
+++ b/scripts/generate_config_schema.py
@@ -68,5 +68,13 @@ def generate_schema(output_path: Path):
 
 if __name__ == "__main__":
     generate_schema(
-        Path("..", "src", "ng_model_gym", "nss", "configs", "schema_config.json")
+        Path(
+            "..",
+            "src",
+            "ng_model_gym",
+            "usecases",
+            "nss",
+            "configs",
+            "schema_config.json",
+        )
     )


### PR DESCRIPTION
This was missed when doing the recent folder restructuring.

Also add some explanatory comments to the gitignore file regarding the schema json.

Change-Id: I053b790434b2b73d7442667409c012ec0f7e3ea8