### PR TITLE
Multi-process dataloader improvements:

### DIFF
--- a/src/ng_model_gym/core/utils/config_model.py
+++ b/src/ng_model_gym/core/utils/config_model.py
@@ -83,10 +83,11 @@ class Dataset(PydanticConfigModel):
     gt_augmentation: bool = Field(
         description="Enable dataset augmentations e.g flips, rotations"
     )
-    num_workers: int = Field(ge=1, description="Number of dataloader workers to use")
+    num_workers: int = Field(ge=0, description="Number of dataloader workers to use")
     prefetch_factor: int = Field(
-        ge=1,
-        description="Number of batches loaded in advance by each dataloader worker",
+        ge=0,
+        description="Number of batches loaded in advance by each dataloader worker. "
+        "Used only if num_workers > 0",
     )
 
 

--- a/src/ng_model_gym/usecases/nss/configs/schema_config.json
+++ b/src/ng_model_gym/usecases/nss/configs/schema_config.json
@@ -75,12 +75,12 @@
         },
         "num_workers": {
             "description": "Number of dataloader workers to use",
-            "minimum": 1,
+            "minimum": 0,
             "type": "integer"
         },
         "prefetch_factor": {
-            "description": "Number of batches loaded in advance by each dataloader worker",
-            "minimum": 1,
+            "description": "Number of batches loaded in advance by each dataloader worker. Used only if num_workers > 0",
+            "minimum": 0,
             "type": "integer"
         }
     },


### PR DESCRIPTION
* Support num_workers=0 to disable multi-processing (a value of 1 doesn't do this).
* Allow prefetch_factor=0. This value is only used when num_workers>0, but it seems sensible to allow the user to choose 0 in the case of num_workers=0.
* Move the custom seed_worker function to file scope - this was causing on error on Windows (see https://docs.pytorch.org/docs/stable/data.html#platform-specific-behaviors). Also remove the call to torch.manual_seed as this shouldn't be necessary - torch already automatically assigns a seed to each worker based on the seed of the main process' torch instance

Change-Id: Ib1664283ad6a0e40fc85d9815f03bae8742f2068