### PR TITLE
Move exr_utils.py to utils module and add test

### DIFF
--- a/tests/unit/utils/test_exr_utils.py
+++ b/tests/unit/utils/test_exr_utils.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: <text>Copyright 2025 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+
+import numpy as np
+import torch
+
+from ng_model_gym.utils.exr_utils import read_exr_torch
+
+
+class TestExrUtils(unittest.TestCase):
+    """Test for reading an EXR file"""
+
+    def test_read_exr_torch(self):
+        """Tests the read_exr_torch function"""
+
+        exr = read_exr_torch(
+            "tests/unit/datasets/test_exr/x2/motion/0002/0000.exr",
+            dtype=np.float32,
+            channels="RGBA",
+        )
+        self.assertEqual(exr.dtype, torch.float32)
+        self.assertEqual(exr.shape, (1, 4, 540, 960))
+        # Check that the data isn't all zero!
+        self.assertGreater(np.max(exr.numpy()), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Previously it was only usable from the safetensors_generator script, but this makes it usable more widely in the repo. This will be used in a following patch for evaluating alternative result sets.

Functions which are not generic EXR functions (validate_exr_dataset_structure and create_depth_params, which are specific to our dataset format) have been moved into dataset_reader.py directly.

Change-Id: Ic239f18b41201602df7aca9cf4a217276370840d