### PR TITLE
MLXPK-1810 Highlight best performing checkpoint after validation

### DIFF
--- a/src/ng_model_gym/api.py
+++ b/src/ng_model_gym/api.py
@@ -107,21 +107,22 @@ def do_training(
 
     log_gpu_torch()
 
-    trained_model = Trainer(params)
+    trainer = Trainer(params)
 
     # Train the model (with optional profiling)
     if profile_setting == ProfilerType.TRACE:
-        _trace_profiler_wrapper(
-            trained_model.train, trace_output_dir=trained_model.model_save_path
-        )
+        _trace_profiler_wrapper(trainer.train, trace_output_dir=trainer.model_save_path)
     elif profile_setting == ProfilerType.GPU_MEMORY:
-        _cuda_profiler_wrapper(
-            trained_model.train, trace_output_dir=trained_model.model_save_path
-        )
+        _cuda_profiler_wrapper(trainer.train, trace_output_dir=trainer.model_save_path)
     else:
-        trained_model.train()
+        trainer.train()
 
-    return trained_model.model, trained_model.latest_model_save_path
+    if params.train.perform_validate:
+        # Return best model ckpt path (as measured by validation results)
+        return trainer.best_model_save_path
+
+    # Return final ckpt path if no validation was executed
+    return trainer.latest_model_save_path
 
 
 @memory_log_decorator

--- a/src/ng_model_gym/cli.py
+++ b/src/ng_model_gym/cli.py
@@ -112,12 +112,9 @@ def train_cli(
             "Config error: Evaluation is specified but no test dataset path is provided"
         )
 
-    trained_model, model_path = do_training(
-        params, TrainEvalMode.FP32, cli_state["profiler"]
-    )
+    model_path = do_training(params, TrainEvalMode.FP32, cli_state["profiler"])
 
     if evaluate:
-        trained_model.nss_model.reset_history_buffers()
         do_evaluate(params, model_path, model_type=TrainEvalMode.FP32)
 
 
@@ -161,12 +158,9 @@ def qat_cli(
             "Config error: Evaluation is specified but no test dataset path is provided"
         )
 
-    trained_model, model_path = do_training(
-        params, TrainEvalMode.QAT_INT8, cli_state["profiler"]
-    )
+    model_path = do_training(params, TrainEvalMode.QAT_INT8, cli_state["profiler"])
 
     if evaluate:
-        trained_model.nss_model.reset_history_buffers()
         do_evaluate(params, model_path, model_type=TrainEvalMode.QAT_INT8)
 
 

--- a/src/ng_model_gym/core/utils/config_model.py
+++ b/src/ng_model_gym/core/utils/config_model.py
@@ -119,9 +119,6 @@ class Checkpoints(PydanticConfigModel):
     """Checkpoints configuration"""
 
     dir: pathlib.Path = Field(description="Save directory for checkpoints")
-    save_frequency: int = Field(
-        gt=0, description="How often to save checkpoints during training"
-    )
 
 
 class CosineAnnealingSchedulerConfig(PydanticConfigModel):

--- a/src/ng_model_gym/usecases/nss/configs/default.json
+++ b/src/ng_model_gym/usecases/nss/configs/default.json
@@ -37,8 +37,7 @@
         "fp32": {
             "number_of_epochs": 15,
             "checkpoints": {
-                "dir": "./checkpoints",
-                "save_frequency": "1"
+                "dir": "./checkpoints"
             },
             "learning_rate": "2e-3",
             "cosine_annealing_scheduler_config": {
@@ -50,8 +49,7 @@
         "qat": {
             "number_of_epochs": 2,
             "checkpoints": {
-                "dir": "./checkpoints/qat_checkpoints",
-                "save_frequency": "1"
+                "dir": "./checkpoints/qat_checkpoints"
             },
             "learning_rate": "6e-4",
             "cosine_annealing_scheduler_config": {

--- a/src/ng_model_gym/usecases/nss/configs/schema_config.json
+++ b/src/ng_model_gym/usecases/nss/configs/schema_config.json
@@ -186,11 +186,6 @@
                     "description": "Save directory for checkpoints",
                     "format": "path",
                     "type": "string"
-                },
-                "save_frequency": {
-                    "description": "How often to save checkpoints during training",
-                    "exclusiveMinimum": 0,
-                    "type": "integer"
                 }
             },
             "learning_rate": {
@@ -225,11 +220,6 @@
                     "description": "Save directory for checkpoints",
                     "format": "path",
                     "type": "string"
-                },
-                "save_frequency": {
-                    "description": "How often to save checkpoints during training",
-                    "exclusiveMinimum": 0,
-                    "type": "integer"
                 }
             },
             "learning_rate": {

--- a/tests/unit/test_scripts/test_config.py
+++ b/tests/unit/test_scripts/test_config.py
@@ -43,7 +43,6 @@ class TestConfig(unittest.TestCase):
 
         params = create_simple_params()
         params.train.seed = 9876
-        params.train.fp32.checkpoints.save_frequency = 100
         params = params.model_dump_json()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -58,7 +57,6 @@ class TestConfig(unittest.TestCase):
 
                 # Check user config overrides default params
                 self.assertEqual(user_config.train.seed, 9876)
-                self.assertEqual(user_config.train.fp32.checkpoints.save_frequency, 100)
 
     def test_config_validation(self):
         """Test validation logic is present"""

--- a/tests/unit/utils/utils.py
+++ b/tests/unit/utils/utils.py
@@ -80,7 +80,6 @@ def create_simple_params(
                 "number_of_epochs": 1,
                 "checkpoints": {
                     "dir": checkpoints,
-                    "save_frequency": "1",
                 },
                 "learning_rate": "2e-3",
                 "cosine_annealing_scheduler_config": {
@@ -92,7 +91,6 @@ def create_simple_params(
                 "number_of_epochs": 1,
                 "checkpoints": {
                     "dir": f"{checkpoints}/qat_checkpoints",
-                    "save_frequency": "1",
                 },
                 "learning_rate": "6e-4",
                 "cosine_annealing_scheduler_config": {


### PR DESCRIPTION
- When performing validation, copies the best performing ckpt to a best-validated-ckpt.pt file along with its metadata in best-validated-ckpt.meta.json
- No longer return model instance from do_training -- model_paths are returned on their own
- Reset history buffers at the end of any .train() or .validate() method as a precutionary measure
- Remove save_frequency config arg. Save weights after every epoch

Signed-off-by: James Ward <james.ward@arm.com>
Change-Id: Ib9d7c9bd67ea50c01ad5ba9f5bf15242cec2350b
