### PR TITLE
Add helper function to auto-register usecase models

### DIFF
--- a/src/ng_model_gym/usecases/__init__.py
+++ b/src/ng_model_gym/usecases/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: <text>Copyright 2025 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+import importlib
+import os
+from pathlib import Path
+
+
+def import_usecase_files() -> None:
+    """Function to import usecase models. This can be called to ensure models are imported."""
+    import_path = Path(__name__)
+    usecases_dir = f'{__file__.replace("__init__.py", "")}'
+    for subdir, _, files in os.walk(usecases_dir):
+        # Convert file path (path/to/module) to module import path (path.to.module)
+        import_path = subdir.replace("/", ".").split("neural-graphics-model-gym.src.")[
+            -1
+        ]
+
+        for file in files:
+            if file.endswith(".py") and not file.startswith("__"):
+                module_name = file[:-3]  # Remove the .py extension
+                importlib.import_module(f"{import_path}.{module_name}")
+                print(f"Imported module: {import_path}.{module_name}")


### PR DESCRIPTION
- **MLXPK-1814: Refactor NSS model to inherit from base model (#34)**
- **MLXPK-1797 Implement a simple Registry (#36)**
- **Add run_scenario.py to scripts/ (#37)**
- **MLXPK-1815: Implement an adapter for the dataset and model registries (#38)**
- **MLXPK-1810 Highlight best performing checkpoint after validation (#39)**
- **MLXPK-1817: Refactored QATNSSModel into BaseNGModel (#40)**
- **MLXPK-1482: Move history buffers into FeedbackModel (#41)**
- **Refactor tests into core/usecases layout to match src/ (#42)**
- **MLXPK-1818 Loss function selected based on config (#43)**
- **MLXPK-1799 Add helper to automatically register all usecase models**
