### PR TITLE
MLXPK-1846: Improve model tracing

### DIFF
--- a/src/ng_model_gym/core/model/base_ng_model.py
+++ b/src/ng_model_gym/core/model/base_ng_model.py
@@ -127,8 +127,7 @@ class BaseNGModel(nn.Module, ABC):
 
     def quantize_modules(
         self,
-        input_shape: Tuple[int, ...],
-        device: torch.device,
+        input_data: Tuple[Any, ...],
         tosa_spec: Optional[ExportSpec] = ExportSpec.TOSA_INT,
     ) -> None:
         """
@@ -235,9 +234,7 @@ class BaseNGModel(nn.Module, ABC):
             )
 
         # Grab the relevant layer to quantize
-        quantized_network = trace_and_quantize_module(
-            current_network, (torch.randn(*input_shape, device=device),)
-        )
+        quantized_network = trace_and_quantize_module(current_network, input_data)
 
         self.set_neural_network(quantized_network)
 

--- a/src/ng_model_gym/core/model/model_tracer.py
+++ b/src/ng_model_gym/core/model/model_tracer.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: <text>Copyright 2025 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Tuple
+
+import torch
+from torch import nn
+from torch.utils._pytree import tree_map
+
+from ng_model_gym.core.model.base_ng_model import BaseNGModel
+from ng_model_gym.core.utils.tensor_types import TensorData
+
+
+def model_tracer(ng_model: BaseNGModel, input_data: TensorData) -> Tuple[Any, ...]:
+    """Trace PyTorch module to capture forward pass tensors"""
+
+    # Move input data to GPU
+    to_gpu = lambda x: x.to("cuda") if isinstance(x, torch.Tensor) else x
+    # tree_map is an internal torch util to traverse containers with tensors
+    input_data = tree_map(to_gpu, input_data)
+
+    target_module_to_trace = ng_model.get_neural_network()
+
+    captured = None
+
+    class _StopForward(Exception):
+        """Custom exception"""
+
+    def capture_forward_input_callback(module: nn.Module, forward_input: Tuple[any]):
+        """Get forward pass inputs of a module"""
+
+        if module is target_module_to_trace:
+            nonlocal captured
+
+            captured = forward_input
+
+            # Raise to stop forward pass
+            raise _StopForward()
+
+        raise RuntimeError("Model tracer did not capture valid module")
+
+    hook = target_module_to_trace.register_forward_pre_hook(
+        capture_forward_input_callback, with_kwargs=False
+    )
+    try:
+        with torch.no_grad():
+            try:
+                # Run model forward with callback hook
+                ng_model(input_data)
+            except _StopForward:
+                pass
+    finally:
+        hook.remove()
+
+    match captured:
+        case None | (None,):
+            raise ValueError(
+                "Model tracer capture is None. Most likely input_data to tracer is "
+                "empty or something went wrong with data passed into model forward pass."
+            )
+        case _:
+            return captured

--- a/src/ng_model_gym/core/trainer/trainer.py
+++ b/src/ng_model_gym/core/trainer/trainer.py
@@ -19,6 +19,7 @@ from ng_model_gym.core.data.utils import DataLoaderMode
 from ng_model_gym.core.evaluator.metrics import get_metrics
 from ng_model_gym.core.loss.losses import LossV1
 from ng_model_gym.core.model.model import create_model
+from ng_model_gym.core.model.model_tracer import model_tracer
 from ng_model_gym.core.optimizers.adam_w import adam_w_torch
 from ng_model_gym.core.optimizers.lars_adam import lars_adam_torch
 from ng_model_gym.core.schedulers.lr_scheduler import CosineAnnealingWithWarmupLR
@@ -104,12 +105,11 @@ class Trainer:
             self.model.nss_model.is_qat_model
             and not self.model.nss_model.is_network_quantized
         ):
-            autoencoder_input = self.model.get_model_input_for_tracing(
-                next(iter(self.train_dataloader))[0]
-            )
+            input_data = next(iter(self.train_dataloader))[0]
+            forward_input_data = model_tracer(self.model, input_data)
+
             self.model.nss_model.quantize_modules(
-                autoencoder_input.shape,
-                device=self.device,
+                forward_input_data,
             )
 
     def _restore_model_weights(self):

--- a/src/ng_model_gym/core/utils/checkpoint_utils.py
+++ b/src/ng_model_gym/core/utils/checkpoint_utils.py
@@ -106,8 +106,15 @@ def load_checkpoint(model_path: Path, params: ConfigModel, device: torch.device 
         and not trained_model.nss_model.is_network_quantized
     ):
         trained_model.nss_model.quantize_modules(
-            (8, trained_model.nss_model.autoencoder.in_channels, 128, 128),
-            device=device,
+            (
+                torch.randn(
+                    8,
+                    trained_model.nss_model.autoencoder.in_channels,
+                    128,
+                    128,
+                    device=device,
+                ),
+            ),
         )
 
     logger.info(f"Loading model from checkpoint: {model_path}")

--- a/src/ng_model_gym/usecases/nss/model/model_v1.py
+++ b/src/ng_model_gym/usecases/nss/model/model_v1.py
@@ -56,9 +56,6 @@ class NSSModel(BaseNGModel):
 
         self.autoencoder = AutoEncoderV1(feedback_ch=self.feedback_ch, batch_norm=True)
 
-        # Store input tensor to autoencoder for future use when tracing model is required
-        self.autoencoder_input_tensor: Optional[torch.Tensor] = None
-
         self.scale = params.train.scale
 
         self.dm_scale_on_no_motion = nn.Parameter(

--- a/tests/core/unit/model/test_model_tracer.py
+++ b/tests/core/unit/model/test_model_tracer.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: <text>Copyright 2025 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from typing import Any, Tuple
+
+import torch
+from torch import nn
+
+from ng_model_gym.core.model.base_ng_model import BaseNGModel
+from ng_model_gym.core.model.model_tracer import model_tracer
+
+# pylint: disable=unsubscriptable-object
+
+
+class TestNN(nn.Module):
+    """Test NN"""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        """Mock forward pass"""
+        return x
+
+
+class TestNGModel(BaseNGModel):
+    """Test NGModel"""
+
+    def __init__(self):
+        super().__init__()
+        self.network = TestNN()
+        self.trigger_bad_preprocessing = False
+
+    def get_neural_network(self) -> nn.Module:
+        """Mock get_neural_network"""
+        return self.network
+
+    def set_neural_network(self, neural_network: nn.Module) -> None:
+        """Mock set_neural_network"""
+        self.network = neural_network
+
+    def mock_preprocess(self, x):
+        """Mock preprocess"""
+        return None if self.trigger_bad_preprocessing else x
+
+    def forward(self, x):
+        """Mock forward pass"""
+        x = self.mock_preprocess(x)
+        return self.network(x)
+
+
+class TestModelTracer(unittest.TestCase):
+    """Test model tracer"""
+
+    def test_tracer_captures_input_tensor(self):
+        """Test tracer captures single input tensor"""
+        model = TestNGModel()
+        t1 = torch.randn(2, 4)
+
+        traced_data: Tuple[Any, ...] = model_tracer(model, t1)
+        self.assertIsInstance(traced_data, tuple)
+        self.assertEqual(len(traced_data), 1)
+
+        traced_tensor = traced_data[0]
+        self.assertIsInstance(traced_tensor, torch.Tensor)
+        self.assertTrue(traced_tensor.is_cuda, "traced_tensor should be CUDA")
+
+        torch.testing.assert_close(traced_tensor.cpu(), t1.cpu())
+        self.assertEqual(traced_tensor.dtype, t1.dtype)
+        self.assertEqual(tuple(traced_tensor.shape), tuple(t1.shape))
+
+    def test_tracer_captures_dict_tensor_input(self):
+        """Test tracer captures Dict[str, torch.Tensor]"""
+        model = TestNGModel()
+
+        t1 = torch.randn(2, 4)
+        t2 = torch.randn(3, 4)
+        input_data = {"a": t1, "b": t2}
+
+        traced_data = model_tracer(model, input_data)
+        self.assertIsInstance(traced_data, tuple)
+        self.assertEqual(len(traced_data), 1)
+        traced_data = traced_data[0]
+
+        self.assertIsInstance(traced_data, dict)
+        self.assertEqual(set(traced_data.keys()), {"a", "b"})
+
+        for key, input_tensor in input_data.items():
+            traced_tensor = traced_data[key]
+            self.assertIsInstance(traced_tensor, torch.Tensor, f"{key} not a tensor")
+            self.assertTrue(traced_tensor.is_cuda, f"{key} should be CUDA")
+            self.assertEqual(
+                traced_tensor.dtype, input_tensor.dtype, f"{key} dtype mismatch"
+            )
+            self.assertEqual(
+                tuple(traced_tensor.shape),
+                tuple(input_tensor.shape),
+                f"{key} shape mismatch",
+            )
+            torch.testing.assert_close(
+                traced_tensor.cpu(), input_tensor.cpu(), msg=f"{key} value mismatch"
+            )
+
+    def test_tracer_raise_missing_input_data(self):
+        """Test ValueError is raised if tracer input data is None"""
+        model = TestNGModel()
+        model.trigger_bad_preprocessing = True
+
+        invalid_input_data = None
+
+        with self.assertRaises(ValueError):
+            model_tracer(model, invalid_input_data)
+
+    def test_tracer_raise_missing_bad_forward_input(self):
+        """Test ValueError is raised if model forward input is somehow None"""
+        model = TestNGModel()
+        model.trigger_bad_preprocessing = True
+        t1 = torch.randn(2, 4)
+
+        with self.assertRaises(ValueError):
+            model_tracer(model, t1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/unit/utils/test_export_utils.py
+++ b/tests/core/unit/utils/test_export_utils.py
@@ -50,6 +50,14 @@ class MockFeedbackModel:
         """Mock method to return model input for tracing."""
         return x
 
+    def get_neural_network(self):
+        """Mock get_neural_network"""
+        return self.nss_model.get_neural_network()
+
+    def set_neural_network(self, nn):
+        """Mock set_neural_network"""
+        self.nss_model = nn
+
 
 # pylint: disable-next=unused-argument
 def fake_dl(params, num_workers, prefetch_factor, loader_mode, trace_mode):
@@ -96,6 +104,10 @@ class TestExportUtils(unittest.TestCase):
     )
     @patch("ng_model_gym.core.utils.export_utils._export_module_to_vgf", new=DEFAULT)
     @patch("ng_model_gym.core.utils.export_utils._check_cuda", new=lambda: None)
+    @patch(
+        "ng_model_gym.core.utils.export_utils.model_tracer",
+        new=lambda model, preprocess: torch.zeros(1, 1),
+    )
     def test_qat_int8_path(
         self, mock_export_module_to_vgf, mock_get_dataloader, mock_update_metadata_file
     ):
@@ -149,6 +161,10 @@ class TestExportUtils(unittest.TestCase):
     )
     @patch("ng_model_gym.core.utils.export_utils._export_module_to_vgf", new=DEFAULT)
     @patch("ng_model_gym.core.utils.export_utils._check_cuda", new=lambda: None)
+    @patch(
+        "ng_model_gym.core.utils.export_utils.model_tracer",
+        new=lambda model, preprocess: torch.zeros(1, 1),
+    )
     def test_fp32_path(
         self, mock_export_module_to_vgf, mock_get_dataloader, mock_update_metadata_file
     ):
@@ -201,6 +217,10 @@ class TestExportUtils(unittest.TestCase):
     @patch(
         "ng_model_gym.core.utils.export_utils._export_module_to_vgf",
         new=lambda *a, **k: None,
+    )
+    @patch(
+        "ng_model_gym.core.utils.export_utils.model_tracer",
+        new=lambda model, preprocess: torch.zeros(1, 1),
     )
     def test_metadata_file_is_created(self):
         """Test that metadata file is created with constants when exporting."""


### PR DESCRIPTION
* Tracing model for network input now works on any BaseNGModel
* Traced data is tensors instead of tensor shape
* User models can now have multiple inputs into the forward pass
* Model forward inputs can be tensor containers  e.g dict, list

Change-Id: Id1a2f6df4bd13df009251569b12f7d1dfb550042
Signed-off-by: Ayaan Masood <ayaan.masood@arm.com>
