### PR TITLE
MLXPK-1820 LR schedule selected based on config

### DIFF
--- a/scripts/generate_config_schema.py
+++ b/scripts/generate_config_schema.py
@@ -27,6 +27,7 @@ def format_schema(schema):
         "required",
         "additionalProperties",
         "model_train_eval_mode",
+        "mapping",
     ] + [key for key in ("description", "type") if schema.get("type") == "object"]
 
     for key, value in schema.items():

--- a/src/ng_model_gym/usecases/nss/configs/default.json
+++ b/src/ng_model_gym/usecases/nss/configs/default.json
@@ -44,10 +44,14 @@
             "checkpoints": {
                 "dir": "./checkpoints"
             },
-            "learning_rate": "2e-3",
-            "cosine_annealing_scheduler_config": {
+            "lr_scheduler": {
+                "type": "cosine_annealing",
                 "warmup_percentage": 0.05,
                 "min_lr": 2e-4
+            },
+            "optimizer": {
+                "optimizer_type": "lars_adam",
+                "learning_rate": "2e-3"
             }
         },
 
@@ -56,16 +60,16 @@
             "checkpoints": {
                 "dir": "./checkpoints/qat_checkpoints"
             },
-            "learning_rate": "6e-4",
-            "cosine_annealing_scheduler_config": {
+            "lr_scheduler": {
+                "type": "cosine_annealing",
                 "warmup_percentage": 0.05,
                 "min_lr": 1e-5
+            },
+            "optimizer": {
+                "optimizer_type": "lars_adam",
+                "learning_rate": "2e-3"
             }
         }
-    },
-    "optimizer": {
-        "learning_rate_scheduler": "cosine_annealing",
-        "optimizer_type": "lars_adam"
     },
     "processing": {
         "shader_accurate": false

--- a/src/ng_model_gym/usecases/nss/configs/schema_config.json
+++ b/src/ng_model_gym/usecases/nss/configs/schema_config.json
@@ -222,23 +222,72 @@
                     "type": "string"
                 }
             },
-            "learning_rate": {
-                "description": "The learning rate. Scheduler may override this value",
-                "exclusiveMinimum": 0.0,
-                "maximum": 1.0,
-                "type": "number"
-            },
-            "cosine_annealing_scheduler_config": {
-                "warmup_percentage": {
-                    "description": "Proportion of training steps to linearly warm up the learning rate",
-                    "exclusiveMaximum": 1.0,
-                    "minimum": 0.0,
-                    "type": "number"
+            "lr_scheduler": {
+                "description": "The Learning Rate Scheduler used during training. Can be one of: cosine_annealing, exponential, static",
+                "discriminator": {
+                    "propertyName": "type"
                 },
-                "min_lr": {
-                    "description": "Minimum learning rate reached after cosine decay.",
+                "oneOf": [
+                    {
+                        "type": {
+                            "const": "cosine_annealing",
+                            "type": "string"
+                        },
+                        "warmup_percentage": {
+                            "description": "Proportion of training steps to linearly warm up the learning rate",
+                            "exclusiveMaximum": 1.0,
+                            "minimum": 0.0,
+                            "type": "number"
+                        },
+                        "min_lr": {
+                            "description": "Minimum learning rate reached after cosine decay.",
+                            "maximum": 1.0,
+                            "minimum": 0.0,
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "type": {
+                            "const": "exponential",
+                            "type": "string"
+                        },
+                        "decay_rate": {
+                            "description": "Learning rate decay rate",
+                            "maximum": 1.0,
+                            "minimum": 0.0,
+                            "type": "number"
+                        },
+                        "decay_step": {
+                            "description": "Steps between learning rate decay",
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "type": {
+                            "const": "static",
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "optimizer": {
+                "optimizer_type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "lars_adam",
+                    "description": "Optimizer type to use during training. If not set, defaults to lars_adam."
+                },
+                "learning_rate": {
+                    "description": "The learning rate. Scheduler may override this value",
+                    "exclusiveMinimum": 0.0,
                     "maximum": 1.0,
-                    "minimum": 0.0,
                     "type": "number"
                 }
             }
@@ -256,23 +305,72 @@
                     "type": "string"
                 }
             },
-            "learning_rate": {
-                "description": "The learning rate. Scheduler may override this value",
-                "exclusiveMinimum": 0.0,
-                "maximum": 1.0,
-                "type": "number"
-            },
-            "cosine_annealing_scheduler_config": {
-                "warmup_percentage": {
-                    "description": "Proportion of training steps to linearly warm up the learning rate",
-                    "exclusiveMaximum": 1.0,
-                    "minimum": 0.0,
-                    "type": "number"
+            "lr_scheduler": {
+                "description": "The Learning Rate Scheduler used during training. Can be one of: cosine_annealing, exponential, static",
+                "discriminator": {
+                    "propertyName": "type"
                 },
-                "min_lr": {
-                    "description": "Minimum learning rate reached after cosine decay.",
+                "oneOf": [
+                    {
+                        "type": {
+                            "const": "cosine_annealing",
+                            "type": "string"
+                        },
+                        "warmup_percentage": {
+                            "description": "Proportion of training steps to linearly warm up the learning rate",
+                            "exclusiveMaximum": 1.0,
+                            "minimum": 0.0,
+                            "type": "number"
+                        },
+                        "min_lr": {
+                            "description": "Minimum learning rate reached after cosine decay.",
+                            "maximum": 1.0,
+                            "minimum": 0.0,
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "type": {
+                            "const": "exponential",
+                            "type": "string"
+                        },
+                        "decay_rate": {
+                            "description": "Learning rate decay rate",
+                            "maximum": 1.0,
+                            "minimum": 0.0,
+                            "type": "number"
+                        },
+                        "decay_step": {
+                            "description": "Steps between learning rate decay",
+                            "minimum": 1,
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "type": {
+                            "const": "static",
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "optimizer": {
+                "optimizer_type": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "lars_adam",
+                    "description": "Optimizer type to use during training. If not set, defaults to lars_adam."
+                },
+                "learning_rate": {
+                    "description": "The learning rate. Scheduler may override this value",
+                    "exclusiveMinimum": 0.0,
                     "maximum": 1.0,
-                    "minimum": 0.0,
                     "type": "number"
                 }
             }
@@ -288,29 +386,6 @@
             ],
             "default": "loss_v1",
             "description": "Loss function to use. If not set, defaults to 'loss_v1'"
-        }
-    },
-    "optimizer": {
-        "learning_rate_scheduler": {
-            "description": "Learning rate scheduler to use when training",
-            "enum": [
-                "cosine_annealing",
-                "exponential",
-                "static"
-            ],
-            "type": "string"
-        },
-        "optimizer_type": {
-            "anyOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": "lars_adam",
-            "description": "Optimizer type to use during training. If not set, defaults to lars_adam."
         }
     },
     "processing": {

--- a/tests/core/unit/trainer/test_trainer.py
+++ b/tests/core/unit/trainer/test_trainer.py
@@ -258,7 +258,7 @@ class TestOptimizerFactory(unittest.TestCase):
     # pylint: disable=C0116
     def test_get_optimizer_type_with_valid_lars_adam_fp32(self):
         params = create_simple_params()
-        params.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
+        params.train.fp32.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
 
         mock_trainer = Mock(spec=Trainer)
         mock_trainer.model = TinyModel()
@@ -266,7 +266,6 @@ class TestOptimizerFactory(unittest.TestCase):
         mock_trainer.training_mode_params = params.train.fp32
 
         optimizer_obj = get_optimizer_type(
-            mock_trainer.params,
             mock_trainer.training_mode_params,
             mock_trainer.model.parameters(),
         )
@@ -275,7 +274,7 @@ class TestOptimizerFactory(unittest.TestCase):
 
     def test_get_optimizer_type_with_valid_lars_adam_qat(self):
         params = create_simple_params()
-        params.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
+        params.train.qat.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
 
         mock_trainer = Mock(spec=Trainer)
         mock_trainer.model = TinyModel()
@@ -283,7 +282,6 @@ class TestOptimizerFactory(unittest.TestCase):
         mock_trainer.training_mode_params = params.train.qat
 
         optimizer_obj = get_optimizer_type(
-            mock_trainer.params,
             mock_trainer.training_mode_params,
             mock_trainer.model.parameters(),
         )
@@ -292,7 +290,7 @@ class TestOptimizerFactory(unittest.TestCase):
 
     def test_get_optimizer_type_with_valid_adam_w_fp32(self):
         params = create_simple_params()
-        params.optimizer.optimizer_type = OptimizerType.ADAM_W.value
+        params.train.fp32.optimizer.optimizer_type = OptimizerType.ADAM_W.value
 
         mock_trainer = Mock(spec=Trainer)
         mock_trainer.model = TinyModel()
@@ -300,7 +298,6 @@ class TestOptimizerFactory(unittest.TestCase):
         mock_trainer.training_mode_params = params.train.fp32
 
         optimizer_obj = get_optimizer_type(
-            mock_trainer.params,
             mock_trainer.training_mode_params,
             mock_trainer.model.parameters(),
         )
@@ -308,7 +305,7 @@ class TestOptimizerFactory(unittest.TestCase):
 
     def test_get_optimizer_type_with_valid_adam_w_qat(self):
         params = create_simple_params()
-        params.optimizer.optimizer_type = OptimizerType.ADAM_W.value
+        params.train.qat.optimizer.optimizer_type = OptimizerType.ADAM_W.value
 
         mock_trainer = Mock(spec=Trainer)
         mock_trainer.model = TinyModel()
@@ -316,15 +313,6 @@ class TestOptimizerFactory(unittest.TestCase):
         mock_trainer.training_mode_params = params.train.qat
 
         optimizer_obj = get_optimizer_type(
-            mock_trainer.params,
-            mock_trainer.training_mode_params,
-            mock_trainer.model.parameters(),
-        )
-        mock_trainer.params = params
-        mock_trainer.training_mode_params = params.train.fp32
-
-        optimizer_obj = get_optimizer_type(
-            mock_trainer.params,
             mock_trainer.training_mode_params,
             mock_trainer.model.parameters(),
         )
@@ -332,7 +320,7 @@ class TestOptimizerFactory(unittest.TestCase):
 
     def test_get_optimizer_type_raises_exception(self):
         params = create_simple_params()
-        params.optimizer.optimizer_type = "does_not_exist"
+        params.train.fp32.optimizer.optimizer_type = "does_not_exist"
 
         mock_trainer = Mock(spec=Trainer)
         mock_trainer.model = TinyModel()
@@ -341,7 +329,6 @@ class TestOptimizerFactory(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             _ = get_optimizer_type(
-                mock_trainer.params,
                 mock_trainer.training_mode_params,
                 mock_trainer.model.parameters(),
             )

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -84,27 +84,25 @@ def create_simple_params(
                 "checkpoints": {
                     "dir": checkpoints,
                 },
-                "learning_rate": "2e-3",
-                "cosine_annealing_scheduler_config": {
+                "lr_scheduler": {
+                    "type": "cosine_annealing",
                     "warmup_percentage": 0.05,
                     "min_lr": 2e-4,
                 },
+                "optimizer": {"optimizer_type": "lars_adam", "learning_rate": "2e-3"},
             },
             "qat": {
                 "number_of_epochs": 1,
                 "checkpoints": {
                     "dir": f"{checkpoints}/qat_checkpoints",
                 },
-                "learning_rate": "6e-4",
-                "cosine_annealing_scheduler_config": {
+                "lr_scheduler": {
+                    "type": "cosine_annealing",
                     "warmup_percentage": 0.05,
                     "min_lr": 1e-5,
                 },
+                "optimizer": {"optimizer_type": "lars_adam", "learning_rate": "2e-3"},
             },
-        },
-        "optimizer": {
-            "learning_rate_scheduler": "cosine_annealing",
-            "optimizer_type": "lars_adam",
         },
     }
 
@@ -116,4 +114,9 @@ def create_simple_params(
     # QAT checkpoints dir
     create_directory(default_params["train"]["qat"]["checkpoints"]["dir"])
 
-    return ConfigModel.model_validate(default_params)
+    return validate_params(default_params)
+
+
+def validate_params(params: dict) -> ConfigModel:
+    """Validate params dict and return ConfigModel object."""
+    return ConfigModel.model_validate(params)


### PR DESCRIPTION
- Simplify config to allow setting different lr_schedulers along with their different params via the same field
- Implemented in config by a Discriminated Union of the different scheduler configs. Each of these config classes inherit from a Base scheduler class which has a discriminator field to be set in each of the implemented scheduler classes
- Testing improved to highlight incorrect/missing field validation errors for the scheduler config in particular
- Moved optimizer to fp32/qat sections. Moved learning_rate under optimizer.

Signed-off-by: James Ward <james.ward@arm.com>
Change-Id: I944c0a98d5e72c27de506eb28809be07ce91202b
