### PR TITLE
Update LICENSE.md to mention `model_export.py`

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -231,7 +231,7 @@ license text is included in, or next to, those files.
   code must also be made under the terms of [Apache License 2.0](./LICENSES/Apache-2.0.txt).
   Relevant files:
 
-   - `src/ng_model_gym/core/utils/export_utils.py`
+   - `src/ng_model_gym/core/export/model_export.py`
    - `src/ng_model_gym/core/utils/patch/executorch_patch.py`
 
 - Some code replicates functionality from the [TensorFlow](https://github.com/tensorflow/tensorflow) project.


### PR DESCRIPTION

* `src/ng_model_gym/core/utils/export_utils.py` was previously moved to `src/ng_model_gym/core/export/model_export.py`
* Updated LICENSE.md to account for this change