### PR TITLE
[MLMOD-333] Improve error handling over batch size

### DIFF
--- a/src/ng_model_gym/core/data/dataloader.py
+++ b/src/ng_model_gym/core/data/dataloader.py
@@ -15,6 +15,8 @@ from ng_model_gym.core.data.dataset_registry import DATASET_REGISTRY, get_datase
 
 logger = logging.getLogger(__name__)
 
+_TRACE_MODE_DESCRIPTION = "trace mode (for FP32/PTQ export)"
+
 
 def seed_worker(worker_id):  # pylint: disable=unused-argument
     """
@@ -66,6 +68,57 @@ def get_dataset(
     return dataset
 
 
+def _get_dataloader_batch_size(
+    configured_batch_size: int,
+    dataset_size: int,
+    loader_mode: DataLoaderMode,
+    trace_mode: bool,
+):
+    """
+    Gets the batch size that should be used for DataLoader objects with
+    specified attributes.
+
+    Args:
+        configured_batch_size: Batch size from user configuration (assumed
+           positive). Throws ValueError if the configured batch size is out of
+           range.
+        dataset_size: Length of the dataset about to be loaded.
+        loader_mode: Dataloader setting - TRAIN, VALIDATION or TEST.
+        trace_mode: Whether the related dataloader returned is for tracing at
+            export. Should be False for QAT.
+    """
+    if loader_mode == DataLoaderMode.TEST:
+        if trace_mode:
+            raise ValueError(
+                "TEST dataloader mode cannot be used "
+                f"together with {_TRACE_MODE_DESCRIPTION}."
+            )
+
+        batch_size = 1
+    elif configured_batch_size <= dataset_size:
+        batch_size = configured_batch_size
+    else:
+        raise ValueError(
+            f"Batch size ({configured_batch_size}) is larger "
+            "than the dataset. Reduce batch size to "
+            f"{dataset_size} or less."
+        )
+
+    if trace_mode and batch_size == 1:
+        # Avoid 0/1 Specialization Problem in PT2 Export
+        raise ValueError(
+            f"In {_TRACE_MODE_DESCRIPTION}, the batch size must be 2 or more."
+        )
+
+    if batch_size != configured_batch_size:
+        logger.warning(
+            f"Using batch size of {batch_size} "
+            f"(configured batch size = {configured_batch_size})"
+        )
+
+    return batch_size
+
+
 def get_dataloader(
     config_params: ConfigModel,
     num_workers=1,
@@ -79,25 +132,31 @@ def get_dataloader(
         config_params: Configuration parameters.
         num_workers: Number of workers for the DataLoader to use.
         prefetch_factor: How many batches each worker should try to preload.
-        loader_mode: What mode the dataloader should be set to.
+        loader_mode: Dataloader setting to apply - TRAIN, VALIDATION or TEST.
         trace_mode: Whether the dataloader returned is for tracing at export.
             Should be False for QAT.
 
     Returns:
         PyTorch DataLoader object ready to produce data as configured by passed in parameters.
     """
-
     dataset = get_dataset(config_params, loader_mode)
+    dataset_size = len(dataset)
+
+    if dataset_size <= 0:
+        raise ValueError("Cannot process empty dataset.")
+
+    batch_size = _get_dataloader_batch_size(
+        config_params.train.batch_size, dataset_size, loader_mode, trace_mode
+    )
+
+    messages = ["Loading data"]
 
     if trace_mode:
-        logger.debug(
-            "Loading data in trace mode with batch_size of 2 (for FP32/PTQ export)"
-        )
-        batch_size = 2  # Avoid 0/1 Specialization Problem in PT2 Export
-    else:
-        batch_size = (
-            1 if loader_mode == DataLoaderMode.TEST else config_params.train.batch_size
-        )
+        messages.append(f"in {_TRACE_MODE_DESCRIPTION}")
+
+    messages.append(f"with a batch size of {batch_size}")
+
+    logger.debug(" ".join(messages))
 
     # Shuffle only when training.
     shuffle = loader_mode == DataLoaderMode.TRAIN

--- a/src/ng_model_gym/core/export/model_export.py
+++ b/src/ng_model_gym/core/export/model_export.py
@@ -302,7 +302,7 @@ def executorch_vgf_export(
 
         if params.dataset.path.train is None:
             raise ValueError(
-                "Config error: No path specified for the train dataset."
+                "Config error: No path specified for the train dataset. "
                 "This is required for exporting a QAT model to a VGF file."
             )
 
@@ -310,13 +310,13 @@ def executorch_vgf_export(
     else:
         params.model_train_eval_mode = TrainEvalMode.FP32
 
-        if params.dataset.path.test is None:
+        if params.dataset.path.validation is None:
             raise ValueError(
-                "Config error: No path specified for the test dataset."
+                "Config error: No path specified for the validation dataset. "
                 "This is required for exporting an FP32 model to a VGF file."
             )
 
-        loader_mode = DataLoaderMode.TEST
+        loader_mode = DataLoaderMode.VAL
 
     is_dynamic_input = params.output.export.dynamic_shape
     static_input_shape = params.output.export.vgf_static_input_shape

--- a/src/ng_model_gym/usecases/nfru/data/dataset.py
+++ b/src/ng_model_gym/usecases/nfru/data/dataset.py
@@ -158,9 +158,7 @@ class NFRUDataset(torch.utils.data.Dataset):
 
         # Validate data
         if self.loader_mode_enum == DataLoaderMode.TRAIN and dataset_cfg.health_check:
-            logger.info(
-                "NFRU dataset health check requested but not yet implemented."
-            )
+            logger.info("NFRU dataset health check requested but not yet implemented.")
         # pylint: enable=duplicate-code
 
     def _configure_sliding_window_data_structures(self):

--- a/tests/core/export/test_executorch_integration.py
+++ b/tests/core/export/test_executorch_integration.py
@@ -100,7 +100,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
             with self.subTest(model):
                 # Load config and setup for current test
                 params = create_simple_params(usecase="nss")
-                params.dataset.path.test = Path("tests/usecases/nss/datasets/test")
+                params.dataset.path.validation = Path("tests/usecases/nss/datasets/val")
                 params.output.export.vgf_output_dir = self.tosa_out_dir
                 params.model_train_eval_mode = TrainEvalMode.FP32
                 # Ensure TOSA output directory does not exist
@@ -128,7 +128,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
             # Load config and setup for current test
             params = create_simple_params(usecase="nss")
             params.output.export.vgf_output_dir = self.tosa_out_dir
-            params.dataset.path.test = Path("tests/usecases/nss/datasets/test")
+            params.dataset.path.validation = Path("tests/usecases/nss/datasets/val")
 
             # Ensure TOSA output directory does not exist
             tosa_out_dir = Path(params.output.export.vgf_output_dir)

--- a/tests/core/unit/data/test_dataloader.py
+++ b/tests/core/unit/data/test_dataloader.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ng_model_gym.core.data import DataLoaderMode
+from ng_model_gym.core.data.dataloader import _get_dataloader_batch_size, get_dataloader
+
+
+class TestDataloaderBatchSize(unittest.TestCase):
+    """Tests determination of dataloader batch size."""
+
+    def test_trace_mode_train_val_uses_configured_batch_size(self):
+        """
+        TRAIN and VAL dataloaders should use the configured batch size when in
+        trace mode. (TEST dataloaders use a batch size of 1: see
+        test_test_uses_batch_size_1().)
+        """
+        for loader_mode in [
+            DataLoaderMode.TRAIN,
+            DataLoaderMode.VAL,
+        ]:
+            batch_size = _get_dataloader_batch_size(
+                configured_batch_size=8,
+                dataset_size=16,
+                loader_mode=loader_mode,
+                trace_mode=True,
+            )
+
+            self.assertEqual(batch_size, 8)
+
+    def test_train_val_uses_configured_batch_size(self):
+        """
+        TRAIN and VAL dataloaders should use the explicitly configured batch
+        size when *not* in trace mode. Also confirm that single element batches
+        (edge case) do not produce errors. Compare with
+        test_train_val_trace_mode_cannot_use_batch_size_of_1().
+        """
+        for loader_mode in [
+            DataLoaderMode.TRAIN,
+            DataLoaderMode.VAL,
+        ]:
+            batch_size = _get_dataloader_batch_size(
+                configured_batch_size=1,
+                dataset_size=16,
+                loader_mode=loader_mode,
+                trace_mode=False,
+            )
+
+            self.assertEqual(batch_size, 1)
+
+    def test_train_val_throws_when_batch_size_larger_than_dataset(self):
+        """
+        TRAIN and VAL dataloaders should throw when the batch size is larger
+        than the dataset size.
+        """
+        for loader_mode in [
+            DataLoaderMode.TRAIN,
+            DataLoaderMode.VAL,
+        ]:
+            with pytest.raises(ValueError) as exception_info:
+                _ = _get_dataloader_batch_size(
+                    configured_batch_size=2,
+                    dataset_size=1,
+                    loader_mode=loader_mode,
+                    trace_mode=False,
+                )
+
+            self.assertIn("larger than the dataset", str(exception_info.value))
+
+    def test_test_uses_batch_size_1(self):
+        """
+        TEST dataloaders have a batch size of 1 regardless of configured
+        batch size.
+        """
+
+        batch_size = _get_dataloader_batch_size(
+            configured_batch_size=8,
+            dataset_size=16,
+            loader_mode=DataLoaderMode.TEST,
+            trace_mode=False,
+        )
+
+        self.assertEqual(batch_size, 1)
+
+    def test_test_trace_mode_throws(self):
+        """
+        TEST dataloaders cannot be used in trace mode and should throw an
+        exception.
+        """
+        with pytest.raises(ValueError) as exception_info:
+            _ = _get_dataloader_batch_size(
+                configured_batch_size=8,
+                dataset_size=16,
+                loader_mode=DataLoaderMode.TEST,
+                trace_mode=True,
+            )
+
+        self.assertIn("cannot be used together", str(exception_info.value))
+
+    def test_train_val_trace_mode_cannot_use_batch_size_of_1(self):
+        """
+        TRAIN and VAL dataloaders cannot use a batch size of 1 if in trace
+        mode.
+        """
+        for loader_mode in [
+            DataLoaderMode.TRAIN,
+            DataLoaderMode.VAL,
+        ]:
+            with pytest.raises(ValueError) as exception_info:
+                _ = _get_dataloader_batch_size(
+                    configured_batch_size=1,
+                    dataset_size=16,
+                    loader_mode=loader_mode,
+                    trace_mode=True,
+                )
+
+            self.assertIn("batch size must be 2 or more", str(exception_info.value))
+
+
+class TestGetDataloader(unittest.TestCase):
+    """Tests dataloader construction."""
+
+    @patch("ng_model_gym.core.data.dataloader.get_dataset", return_value=[])
+    def test_raises_on_empty_dataset(self, _mock_get_dataset):
+        """get_dataloader() should reject empty datasets."""
+        config_params = SimpleNamespace(
+            train=SimpleNamespace(batch_size=1, seed=123),
+            dataset=SimpleNamespace(health_check=False),
+        )
+
+        with pytest.raises(ValueError) as exception_info:
+            _ = get_dataloader(config_params)
+
+        self.assertEqual(str(exception_info.value), "Cannot process empty dataset.")

--- a/tests/core/unit/utils/test_export_utils.py
+++ b/tests/core/unit/utils/test_export_utils.py
@@ -101,7 +101,9 @@ def make_params(tmp_path):
     p.dataset = SimpleNamespace(
         num_workers=num_workers,
         prefetch_factor=4,
-        path=SimpleNamespace(train="train_data", test="test_data"),
+        path=SimpleNamespace(
+            train="train_data", test="test_data", validation="test_data"
+        ),
     )
 
     p.model = SimpleNamespace(name="NSS", version="42")
@@ -228,7 +230,7 @@ class TestExportUtils(unittest.TestCase):
 
         # Dataloader correct arguments passed.
         _, kwargs = mock_get_dataloader.call_args
-        self.assertEqual(kwargs["loader_mode"], DataLoaderMode.TEST)
+        self.assertEqual(kwargs["loader_mode"], DataLoaderMode.VAL)
         self.assertTrue(kwargs["trace_mode"])
 
         # Export module to a VGF file called with correct parameters.

--- a/tests/usecases/nss/integration/base_integration.py
+++ b/tests/usecases/nss/integration/base_integration.py
@@ -61,7 +61,8 @@ class NSSBaseIntegrationTest(BaseGPUMemoryTest):
         # integration-test dataset
         self.cfg_json["dataset"]["path"]["train"] = self.train_data_dir
         self.cfg_json["dataset"]["path"]["test"] = self.test_data_dir
-        self.cfg_json["dataset"]["path"]["validation"] = ""
+        # Notice the use of "test" data for both "test" and "validation"
+        self.cfg_json["dataset"]["path"]["validation"] = self.test_data_dir
         self.cfg_json["output"][
             "export_frame_png"
         ] = False  # Speed up integration tests


### PR DESCRIPTION
In test and experimental cases, a user might use datasets which are
smaller than the configured batch size. Unfortunately, since we pass
`drop_last=True` to the `Dataloader` ctor, a dataset which is smaller
than the batch size will be discarded. This is because it happens to be
part of an incomplete final batch. This final batch is, of course, the
_only_ batch. The condition leads to a `ZeroDivisionError`.

This patch throws a more useful error in this case, explaining how to
fix the problem. A new unit test suite contains tests over the
pre-existing batch size calculation and the condition leading to the new
error. We also test the case of an empty dataset (which is now an
error). Other dataloader unit tests could also be added here.

The new logic disallows trace mode and TEST dataloaders being used at
the same time, something that happens during export. This should
previously have been disallowed since TEST dataloaders use a batch size
of 1 and trace mode is supposed to disallow a batch size of 1

Signed-off-by: Mark Thurman <mark.thurman@arm.com>
Change-Id: Ib6d2b93130e0290a57c318c41ba37e03497060ba
