### PR TITLE
[MLMOD-137] Fix logging errors in test_api.py

### DIFF
--- a/tests/core/integration/test_api.py
+++ b/tests/core/integration/test_api.py
@@ -9,7 +9,7 @@ from ng_model_gym.api import do_evaluate, do_training
 from ng_model_gym.core.utils.enum_definitions import ProfilerType, TrainEvalMode
 from ng_model_gym.core.utils.logging_utils import logging_config
 from tests.base_gpu_test import BaseGPUMemoryTest
-from tests.testing_utils import create_simple_params
+from tests.testing_utils import clear_loggers, create_simple_params
 
 
 class ApiCoreIntegrationTest(BaseGPUMemoryTest):
@@ -29,8 +29,10 @@ class ApiCoreIntegrationTest(BaseGPUMemoryTest):
         )
 
     def tearDown(self):
-        shutil.rmtree(self.tmp_dir, ignore_errors=True)
         super().tearDown()
+
+        clear_loggers()
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def test_logging_config_no_mutation(self):
         """logging_config should not modify the config."""


### PR DESCRIPTION
Loggers are being written to after `tests/core/integration/test_api.py`
has finished running tests and the loggers are no longer valid. The log
messages are just connected with logging of statistics.

This patch circumvents the problem by shutting the loggers down before
this issue can occur. I think a more elegant fix might be possible
(perhaps involving changes to the code where the individual loggers are
set up). However, my patch is similar to preexisting test code. For
example, there is a similar workaround in `def tearDown()`, within
`tests/usecases/nss/integration/base_integration.py`.

Change-Id: Ie62df648033b1953bbe7d773c913f0dda3f32da5
Signed-off-by: Mark Thurman <mark.thurman@arm.com>
