### PR TITLE
[MLMOD-317] Remove unused dynamic mask function

### DIFF
--- a/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
+++ b/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
@@ -202,7 +202,6 @@ class NFRUv1Core(nn.Module):
         self.flow_method = _FLOW_METHOD
         self.dynamic_flow = True
         self.of_540 = False
-        self.new_dynamic_mask = False
         self.shader_accurate = shader_accurate
         self.scale_factor = scale_factor
 
@@ -463,7 +462,7 @@ class NFRUv1Core(nn.Module):
         dims_540 = [depth_m1.shape[2], depth_m1.shape[3]]
         dims_270 = [flow_xx_f30_xx.shape[2], flow_xx_f30_xx.shape[3]]
 
-        func_dynamic_mask = self._get_dynamic_mask_fn()
+        func_dynamic_mask = m.calculate_previous_dynamic_mask
         in_dynamic_mask = func_dynamic_mask(
             tv_depth=depth_m1,
             tv_mv_m1_f30_m3=mv_m1_f30_m3,
@@ -529,10 +528,3 @@ class NFRUv1Core(nn.Module):
             "coeffs": self.coeff_softmax(learnt_params),
             "output_mfg": output_mfg,
         }
-
-    def _get_dynamic_mask_fn(self):
-        return (
-            m.calculate_previous_dynamic_mask_v5
-            if self.new_dynamic_mask
-            else m.calculate_previous_dynamic_mask
-        )

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/00_warp_mv.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/00_warp_mv.slang
@@ -193,11 +193,7 @@ public void warp_mv(WARP_MV_PARAMS(DECL))
     // 0 == Valid vector to scatter
     uint8_t dynamic_mask_m1 = uint8_t(sample_tensor_nearest(g.b._DynamicMask, batch, uint(0), output_pixel).r);
     uint8_t dynamic_mask_p1 = uint8_t(
-#if NEW_DYNAMIC_MASK
-        dynamic_mask_v5(cm_p1_f30_m1 * float2(g.pc._OutputDims), mv_p1_f30_m1 * float2(g.pc._OutputDims), MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0
-#else
-        dynamic_mask_v4(cm_p1_f30_m1, mv_p1_f30_m1, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0
-#endif
+        dynamic_mask(cm_p1_f30_m1, mv_p1_f30_m1, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0
     );
 
     // Save dynamic mask to feedback for next set of frames

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/common.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/common.slang
@@ -114,15 +114,7 @@ float2 quantise(float2 x) {
     return float2(q) / c;
 }
 
-float dynamic_mask_v5(float2 a, float2 b, float eps, float tau) {
-    a = quantise(a);
-    b = quantise(b);
-    float diff = length(a - b);
-    float max_len = max(max(length(a), length(b)), tau);
-    return max_len < tau ? 0.0f : float(diff >= eps);
-}
-
-float dynamic_mask_v4(float2 a, float2 b, float eps, float tau)
+float dynamic_mask(float2 a, float2 b, float eps, float tau)
 {
     float diff = length(a - b);
     float denom = max(max(length(a), length(b)), tau);

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/constants.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/constants.slang
@@ -41,14 +41,6 @@
 #endif
 
 /*
-    Enable v5 dynamic mask
-    Default: True
-*/
-#ifndef NEW_DYNAMIC_MASK
-    #define NEW_DYNAMIC_MASK 0 // CHANGE: 0 by default for training
-#endif
-
-/*
     Enable debug texture dumping
     Default: False
 */
@@ -96,25 +88,13 @@
     #define HALF_MIN 0.00006103515625
 #endif
 
-
-#if NEW_DYNAMIC_MASK
-    #ifndef MV_SIMILARITY_NOISE_THRESHOLD
-        #define MV_SIMILARITY_NOISE_THRESHOLD 1.0
-    #endif
-
-    #ifndef MV_SIMILARITY_THRESHOLD
-        #define MV_SIMILARITY_THRESHOLD 0.3
-    #endif
-#else
-    #ifndef MV_SIMILARITY_NOISE_THRESHOLD
-        #define MV_SIMILARITY_NOISE_THRESHOLD 0.001
-    #endif
-
-    #ifndef MV_SIMILARITY_THRESHOLD
-        #define MV_SIMILARITY_THRESHOLD 0.01
-    #endif
+#ifndef MV_SIMILARITY_NOISE_THRESHOLD
+    #define MV_SIMILARITY_NOISE_THRESHOLD 0.001
 #endif
 
+#ifndef MV_SIMILARITY_THRESHOLD
+    #define MV_SIMILARITY_THRESHOLD 0.01
+#endif
 
 #ifndef MAX_VAL
     #define MAX_VAL 1023.0

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/slang_only.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/slang_only.slang
@@ -39,44 +39,7 @@ void calculate_previous_dynamic_mask(
     float4x4 motion_mat_tm1 = tensor_to_float4x4(tv_motion_mat_tm1, idx.x);
     float mask;
     float2 cm_m1_f30_m3 = CalculateCameraMotion(uv, 1.0f-depth_m1, motion_mat_tm1, mask);
-    float dynamic_mask_m1 = float(dynamic_mask_v4(cm_m1_f30_m3, mv_m1_f30_m3, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0);
-
-    // Save dynamic mask to feedback for next set of frames
-    tv_dynamic_mask_p1[uint4(idx.x, 0, idx.yz)] = dynamic_mask_m1;
-}
-
-
-[AutoPyBindCUDA]
-[CUDAKernel]
-[NoDiffThis]
-void calculate_previous_dynamic_mask_v5(
-    TensorView<float> tv_depth,
-    TensorView<float> tv_mv_m1_f30_m3,
-    TensorView<float> tv_motion_mat_tm1,
-    TensorView<float> tv_dynamic_mask_p1,
-)
-{
-    uint tId = (cudaThreadIdx() + cudaBlockIdx() * cudaBlockDim()).x;
-
-    // We Dispatch across `output`'s dimensions
-    uint3 size = tensor_size(tv_depth).xzw; // N C H W -> NHW -> X Z W
-    int H = size.y;
-    int W = size.z;
-    uint3 idx = tensor_idx(tId, size); // N H W
-    if (any(idx >= size)) return;
-
-    float2 uv = float2(idx.yz + 0.5f) * rcp(float2(size.yz));
-
-    float2 mv_m1_f30_m3 = float2(
-        tv_mv_m1_f30_m3[uint4(idx.x, 0, idx.yz)],
-        tv_mv_m1_f30_m3[uint4(idx.x, 1, idx.yz)]
-    )  * float2(size.yz);
-
-    float depth_m1 = tv_depth[uint4(idx.x, 0, idx.yz)];
-    float4x4 motion_mat_tm1 = tensor_to_float4x4(tv_motion_mat_tm1, idx.x);
-    float mask;
-    float2 cm_m1_f30_m3 = CalculateCameraMotion(uv, 1.0f-depth_m1, motion_mat_tm1, mask) * float2(size.yz);
-    float dynamic_mask_m1 = float(dynamic_mask_v5(cm_m1_f30_m3, mv_m1_f30_m3, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0);
+    float dynamic_mask_m1 = float(dynamic_mask(cm_m1_f30_m3, mv_m1_f30_m3, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0);
 
     // Save dynamic mask to feedback for next set of frames
     tv_dynamic_mask_p1[uint4(idx.x, 0, idx.yz)] = dynamic_mask_m1;

--- a/tests/core/unit/utils/test_export_utils.py
+++ b/tests/core/unit/utils/test_export_utils.py
@@ -64,11 +64,11 @@ class MockNSS(BaseNGModel):
         return {"foo": "bar"}
 
 
-class MockNFRUDynamicModel(nn.Module):
+class MockNFRUDynamicModel(BaseNGModel):
     """Minimal module wrapper using the NFRU dynamic export shape contract."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, params):
+        super().__init__(params)
         self.autoencoder = nn.Conv2d(16, 16, kernel_size=1)
 
     def get_neural_network(self):
@@ -386,7 +386,7 @@ class TestExportUtils(unittest.TestCase):
         """Dynamic NFRU export requires even heights and widths."""
         params = make_params(self.tmp_path)
         params.model = SimpleNamespace(name="NFRU", version="1")
-        model = MockNFRUDynamicModel()
+        model = MockNFRUDynamicModel(params)
 
         accepted_input = (torch.rand(1, 16, 4, 6),)
         _export_module_to_vgf(

--- a/tests/usecases/nfru/unit/test_nfru_v1_model.py
+++ b/tests/usecases/nfru/unit/test_nfru_v1_model.py
@@ -15,7 +15,6 @@ from torch import nn
 from ng_model_gym.core.config.config_model import ConfigModel
 from ng_model_gym.core.model import BaseNGModel, create_model
 from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
-from ng_model_gym.usecases.nfru.model.nfru_v1 import m
 from ng_model_gym.usecases.nfru.model.nfru_v1_ne import NFRUAutoEncoder
 from tests.base_gpu_test import BaseGPUMemoryTest
 from tests.testing_utils import create_simple_params
@@ -317,11 +316,6 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
         self.assertEqual(calls["count"], 1)
         self.assertEqual(processed_gt.device, ground_truth.device)
         self.assertEqual(processed_gt.dtype, torch.float32)
-
-    def test_dynamic_mask_selector_uses_reference_default(self) -> None:
-        """Dynamic mask selector should use the v1 reference default."""
-        network = self.model.network
-        self.assertIs(network._get_dynamic_mask_fn(), m.calculate_previous_dynamic_mask)
 
     def test_model_hooks_switch_colour_pipeline_by_split(self) -> None:
         """Explicit lifecycle hooks should select the colour pipeline by split."""


### PR DESCRIPTION
We formerly had two dynamic mask functions. One was never used. This
patch removes the unused function (dynamic_mask_v5) and tidies
surrounding code.

Signed-off-by: Mark Thurman <mark.thurman@arm.com>
Change-Id: Ia51d194e75d7a3b17e393983703013350dd22bfb
