### PR TITLE
[MLMOD-317] NFRU: Use correct default loss fn

### DIFF
--- a/src/ng_model_gym/core/config/schema_config.json
+++ b/src/ng_model_gym/core/config/schema_config.json
@@ -732,7 +732,7 @@
                 }
             ],
             "default": null,
-            "description": "Loss function to use. Choose from: loss_v1, LPIPSSpatialLoss, LPIPSSpatialLossV5"
+            "description": "Loss function to use. Choose from: loss_v1, lpips_spatial_loss_v1"
         },
         "loss_args": {
             "anyOf": [

--- a/src/ng_model_gym/core/loss/losses.py
+++ b/src/ng_model_gym/core/loss/losses.py
@@ -121,37 +121,14 @@ class LossV1(torch.nn.Module):
         return loss
 
 
-class LPIPSSpatialLoss(torch.nn.Module):
-    """Spatial loss that blends L1 and LPIPS metrics."""
-
-    def __init__(self, loss_args: Dict[str, float], device: torch.device):
-        super().__init__()
-        self.loss_args = loss_args
-        if "alpha" not in self.loss_args:
-            raise ValueError("LPIPSSpatialLoss requires 'alpha' in loss_args")
-
-        self.device = device
-        self.L1_loss = torch.nn.L1Loss(reduce=False)
-        self.lpips_loss = lpips.LPIPS().to(self.device)
-
-    def forward(self, y_true, y_pred):
-        """Compute the weighted spatial loss for the given predictions."""
-        y_pred_out = y_pred["output"]
-
-        loss_L1 = self.L1_loss(y_true, y_pred_out)
-        loss_lpips = self.lpips_loss(y_true, y_pred_out)
-        loss = lerp_tensor(loss_L1, loss_lpips, self.loss_args["alpha"]).mean()
-        return loss
-
-
-class LPIPSSpatialLossV5(torch.nn.Module):
+class LPIPSSpatialLossV1(torch.nn.Module):
     """Spatial loss used by the NFRU v1 reference pipeline."""
 
     def __init__(self, loss_args: Dict[str, float], device: torch.device):
         super().__init__()
         self.loss_args = loss_args
         if "alpha" not in self.loss_args:
-            raise ValueError("LPIPSSpatialLossV5 requires 'alpha' in loss_args")
+            raise ValueError("LPIPSSpatialLossV1 requires 'alpha' in loss_args")
 
         self.alpha = float(self.loss_args["alpha"])
         self.device = device
@@ -159,7 +136,7 @@ class LPIPSSpatialLossV5(torch.nn.Module):
         self.lpips_loss = lpips.LPIPS().to(self.device)
 
     def forward(self, y_true: torch.Tensor, y_pred: TensorData) -> torch.Tensor:
-        """Blend L1 and LPIPS with the v5 configuration."""
+        """Blend L1 and LPIPS with the v1 configuration."""
         y_pred_out = y_pred["output"]
 
         loss_l1 = self.l1_loss(y_true, y_pred_out)

--- a/src/ng_model_gym/core/trainer/trainer.py
+++ b/src/ng_model_gym/core/trainer/trainer.py
@@ -18,7 +18,7 @@ from ng_model_gym.core.config.config_model import ConfigModel, TrainingConfig
 from ng_model_gym.core.data.data_utils import DataLoaderMode, move_to_device
 from ng_model_gym.core.data.dataloader import get_dataloader
 from ng_model_gym.core.evaluator.metrics import get_metrics
-from ng_model_gym.core.loss.losses import LossV1, LPIPSSpatialLoss, LPIPSSpatialLossV5
+from ng_model_gym.core.loss.losses import LossV1, LPIPSSpatialLossV1
 from ng_model_gym.core.model.base_ng_model import BaseNGModel
 from ng_model_gym.core.model.checkpoint_loader import (
     latest_checkpoint_in_dir,
@@ -533,12 +533,9 @@ def get_loss_fn(params: ConfigModel, device: torch.device):
 
     if loss_name == LossFn.LOSS_V1:
         return LossV1(params.model.recurrent_samples, device)
-    if loss_name == LossFn.LPIPSSpatialLoss:
+    if loss_name == LossFn.LPIPS_SPATIAL_LOSS_V1:
         loss_args = params.train.loss_args if hasattr(params.train, "loss_args") else {}
-        return LPIPSSpatialLoss(loss_args, device)
-    if loss_name == LossFn.LPIPSSpatialLossV5:
-        loss_args = params.train.loss_args if hasattr(params.train, "loss_args") else {}
-        return LPIPSSpatialLossV5(loss_args, device)
+        return LPIPSSpatialLossV1(loss_args, device)
 
     # Defensive (all enums should be handled above)
     raise ValueError(f"No implementation for loss function {loss_name}")

--- a/src/ng_model_gym/core/utils/enum_definitions.py
+++ b/src/ng_model_gym/core/utils/enum_definitions.py
@@ -49,8 +49,7 @@ class LossFn(str, Enum):
     """Enum of supported loss functions."""
 
     LOSS_V1 = "loss_v1"
-    LPIPSSpatialLoss = "LPIPSSpatialLoss"
-    LPIPSSpatialLossV5 = "LPIPSSpatialLossV5"
+    LPIPS_SPATIAL_LOSS_V1 = "lpips_spatial_loss_v1"
 
 
 class OptimizerType(str, Enum):

--- a/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
+++ b/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
@@ -71,7 +71,7 @@
         "seed": 123456,
         "perform_validate": false,
         "validate_frequency": 1,
-        "loss_fn": "LPIPSSpatialLoss",
+        "loss_fn": "lpips_spatial_loss_v1",
         "loss_args": {
             "alpha": 0.1
         },

--- a/tests/core/unit/loss/test_losses.py
+++ b/tests/core/unit/loss/test_losses.py
@@ -2,10 +2,34 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 import unittest
+from unittest import mock
 
 import torch
 
 from ng_model_gym.core.loss import LossV1
+from ng_model_gym.core.loss.losses import LPIPSSpatialLossV1
+
+
+class MockLPIPS(torch.nn.Module):
+    """LPIPS test double that exposes whether input normalization was requested."""
+
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    def forward(self, image_a, image_b, normalize=False):
+        """Return a deterministic LPIPS value based on the normalize argument."""
+        self.calls.append(
+            {
+                "image_a": image_a,
+                "image_b": image_b,
+                "normalize": normalize,
+            }
+        )
+        value = 0.75 if normalize else 10.0
+        return image_a.new_full(
+            (image_a.shape[0], 1, image_a.shape[-2], image_a.shape[-1]), value
+        )
 
 
 class TestLossV1(unittest.TestCase):
@@ -41,3 +65,64 @@ class TestLossV1(unittest.TestCase):
 
         loss = criterion(y_true, y_pred)
         self.assertAlmostEqual(loss.item(), loss_input["loss"], places=3)
+
+
+class TestLPIPSSpatialLossV1(unittest.TestCase):
+    """Tests for LPIPSSpatialLossV1 class"""
+
+    @mock.patch("ng_model_gym.core.loss.losses.lpips.LPIPS")
+    def test_uses_normalized_lpips_when_blending_with_l1(self, mock_lpips):
+        """Test v1 blends L1 with normalized LPIPS."""
+        lpips_loss = MockLPIPS()
+        mock_lpips.return_value = lpips_loss
+        y_true = torch.tensor(
+            [
+                [
+                    [[0.0, 0.2], [0.4, 0.6]],
+                    [[0.1, 0.3], [0.5, 0.7]],
+                    [[0.2, 0.4], [0.6, 0.8]],
+                ]
+            ]
+        )
+        y_pred_out = torch.tensor(
+            [
+                [
+                    [[0.5, 0.2], [0.9, 0.1]],
+                    [[0.0, 0.6], [0.5, 1.0]],
+                    [[0.6, 0.3], [0.2, 0.8]],
+                ]
+            ]
+        )
+        criterion = LPIPSSpatialLossV1({"alpha": 0.25}, torch.device("cpu"))
+
+        loss = criterion(y_true, {"output": y_pred_out})
+
+        l1_loss = torch.nn.functional.l1_loss(y_true, y_pred_out, reduction="none")
+        normalized_lpips_loss = torch.full((1, 1, 2, 2), 0.75)
+        expected_loss = (l1_loss * 0.75 + normalized_lpips_loss * 0.25).mean()
+        self.assertTrue(torch.allclose(loss, expected_loss))
+        self.assertEqual(len(lpips_loss.calls), 1)
+        self.assertIs(lpips_loss.calls[0]["image_a"], y_true)
+        self.assertIs(lpips_loss.calls[0]["image_b"], y_pred_out)
+        self.assertTrue(lpips_loss.calls[0]["normalize"])
+
+    @mock.patch("ng_model_gym.core.loss.losses.lpips.LPIPS")
+    def test_alpha_one_returns_normalized_lpips_term(self, mock_lpips):
+        """Test alpha fully selects the v1 normalized LPIPS term."""
+        lpips_loss = MockLPIPS()
+        mock_lpips.return_value = lpips_loss
+        y_true = torch.zeros((2, 3, 4, 4))
+        y_pred_out = torch.ones((2, 3, 4, 4))
+        criterion = LPIPSSpatialLossV1({"alpha": 1.0}, torch.device("cpu"))
+
+        loss = criterion(y_true, {"output": y_pred_out})
+
+        self.assertEqual(loss.item(), 0.75)
+        self.assertTrue(lpips_loss.calls[0]["normalize"])
+
+    def test_requires_alpha_loss_arg(self):
+        """Test alpha is required to avoid ambiguous blending behaviour."""
+        with self.assertRaisesRegex(
+            ValueError, "LPIPSSpatialLossV1 requires 'alpha' in loss_args"
+        ):
+            LPIPSSpatialLossV1({}, torch.device("cpu"))


### PR DESCRIPTION
An incorrect spatial loss function was used by default in the NFRU case.
This function was referred to as `LPIPSSpatialLoss` in configuration
files (see configuration key `train` → `loss_fn`).

This patch:
- Removes loss function `LPIPSSpatialLoss`
- Renames loss function `LPIPSSpatialLossV5` to `lpips_spatial_loss_v1`.
  This normalizes the version number and formats the identifier
  similarly to the preexisting `loss_v1` loss function.
- Makes `lpips_spatial_loss_v1` the default NFRU loss function.
- Adds a test for NFRU loss functions, consistent with existing tests.

Signed-off-by: Mark Thurman <mark.thurman@arm.com>
Change-Id: I8ca981bb607dadeac7bad47588db50901693c2d8
