### PR TITLE
MLMOD-190: Revert /tmp folder workaround

### DIFF
--- a/src/ng_model_gym/core/config/config_model.py
+++ b/src/ng_model_gym/core/config/config_model.py
@@ -2,7 +2,6 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
-import tempfile
 from numbers import Real
 from typing import Annotated, Any, List, Literal, Optional, Union
 
@@ -298,25 +297,6 @@ class Export(PydanticConfigModel):
     vgf_output_dir: pathlib.Path = Field(
         description="Output directory for the VGF file"
     )
-
-    @field_validator("vgf_output_dir", mode="after")
-    @classmethod
-    def _validate_vgf_output_dir(cls, value: pathlib.Path) -> pathlib.Path:
-        """Disallow temp paths for vgf output dir"""
-        temp_root = pathlib.Path(tempfile.gettempdir()).resolve(strict=False)
-        path = value.expanduser().resolve(strict=False)
-
-        try:
-            path.relative_to(temp_root)
-        except ValueError:
-            return path  # Success, path is not in a tmp dir
-
-        # If path.relative_to() did not raise an error, that means path is in /tmp folder
-        raise PydanticCustomError(
-            "TempDir",
-            "vgf_output_dir must not be under the system temp directory. "
-            "Choose a path to a persistent directory ",
-        )
 
 
 class Output(PydanticConfigModel):

--- a/tests/core/export/test_executorch_integration.py
+++ b/tests/core/export/test_executorch_integration.py
@@ -23,11 +23,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
     def setUpClass(cls):
         """Run only once before executing tests."""
         cls.startTimeTotal = time.time()
-        repo_root = Path(__file__).resolve().parents[3]
-        output_root = repo_root / "output"
-        output_root.mkdir(parents=True, exist_ok=True)
-        # ExecuTorch skips tosa/vgf output under system temp dir
-        cls.test_dir = tempfile.mkdtemp(prefix="tmp-test", dir=output_root)
+        cls.test_dir = tempfile.mkdtemp()
         cls.tosa_out_dir = Path(cls.test_dir) / "tosa"
 
     @classmethod

--- a/tests/scripts/test_config.py
+++ b/tests/scripts/test_config.py
@@ -91,31 +91,6 @@ class TestConfig(unittest.TestCase):
 
             temp_path.unlink(missing_ok=True)
 
-    def test_reject_vgf_output_dir_in_tmp(self):
-        """Test vgf_output_dir cannot be set to a temp directory"""
-        user_config = create_simple_params(usecase="nss").model_dump_json()
-        user_config_dict = json.loads(user_config)
-        user_config_dict["output"]["export"]["vgf_output_dir"] = str(
-            Path(tempfile.gettempdir()) / "vgf"
-        )
-        user_config = json.dumps(user_config_dict)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            with tempfile.NamedTemporaryFile(
-                dir=tmp_dir, mode="w+", suffix=".json", delete=False
-            ) as temp_file:
-                temp_file.write(user_config)
-                temp_file.flush()
-                temp_path = Path(temp_file.name)
-
-            with redirect_stdout(StringIO()):
-                with self.assertRaises(SystemExit) as e:
-                    load_config_file(temp_path)
-
-            self.assertEqual(e.exception.code, 1)
-
-            temp_path.unlink(missing_ok=True)
-
     def test_outdated_config_validation(self):
         """Test exception raised when parameter in user config is outdated"""
 

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -1,13 +1,10 @@
 # SPDX-FileCopyrightText: <text>Copyright 2024-2026 Arm Limited and/or
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
-import atexit
 import copy
 import logging
 import platform
-import shutil
 import tempfile
-from pathlib import Path
 
 import numpy as np
 
@@ -129,13 +126,6 @@ def create_simple_params(
     # own path for these fields.
     temp_dir = tempfile.mkdtemp()
 
-    vgf_output_tmp_dir = Path(
-        tempfile.mkdtemp(prefix="tmp-test-", dir=Path(".").resolve())
-    )
-    atexit.register(shutil.rmtree, vgf_output_tmp_dir, ignore_errors=True)
-
-    export_dir = vgf_output_tmp_dir / "vgf"
-
     default_params = {
         "model": model,
         "processing": {"shader_accurate": False},
@@ -145,7 +135,7 @@ def create_simple_params(
             "export_frame_png": False,
             "tensorboard_output_dir": temp_dir,
             "export": {
-                "vgf_output_dir": str(export_dir),
+                "vgf_output_dir": temp_dir,
                 "dynamic_shape": True,
             },
         },

--- a/tests/usecases/nfru/integration/test_api.py
+++ b/tests/usecases/nfru/integration/test_api.py
@@ -39,11 +39,6 @@ class ApiIntegrationTest(NFRUBaseIntegrationTest):
 
         self.MODEL_FILE = Path("tests/usecases/nfru/weights/nfru_v1_fp32.pt")
 
-    def _get_output_root(self):
-        """Gets a directory for exports, without checking that it exists"""
-        repo_root = Path(__file__).resolve().parents[4]
-        return repo_root / "output"
-
     def test_do_training_no_mutation(self):
         """do_training should not modify the config and return a model."""
         self.config.model_train_eval_mode = TrainEvalMode.FP32
@@ -73,7 +68,7 @@ class ApiIntegrationTest(NFRUBaseIntegrationTest):
         Check that do_export() doesn't change its inputs and does create an
         output file. Configure self.config as necessary before calling.
         """
-        with tempfile.TemporaryDirectory(dir=self._get_output_root()) as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             export_dir = Path(tmp_dir) / "export" / "vgf"
             self.config.output.export.vgf_output_dir = export_dir
 

--- a/tests/usecases/nss/integration/test_api.py
+++ b/tests/usecases/nss/integration/test_api.py
@@ -52,12 +52,8 @@ class ApiIntegrationTest(NSSBaseIntegrationTest):
         """do_export should not modify the config and produce output files."""
         # Train a model to generate a checkpoint to read from in export
         do_training(self.config, TrainEvalMode.FP32, ProfilerType.DISABLED)
-        # Set an export directory under the project output folder
-        repo_root = Path(__file__).resolve().parents[4]
-        output_root = repo_root / "output"
-        output_root.mkdir(parents=True, exist_ok=True)
 
-        with tempfile.TemporaryDirectory(dir=output_root) as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             export_dir = Path(tmp_dir) / "export" / "vgf"
             model_file = Path("tests/usecases/nss/weights/nss_v0.1.0_fp32.pt")
             self.config.output.export.vgf_output_dir = export_dir


### PR DESCRIPTION
* Reverted test code back to outputting vgf artifacts into the /tmp directory
* Fixes workaround introduced in commit 060f0dc

Signed-off-by: Ayaan Masood <ayaan.masood@arm.com>
Change-Id: I323a6df6e2089fd2aa2d980f1f0dc07ca95ab8ff
