### PR TITLE
[MLMOD-410] NFRU: Restore optional dynamic mask function

### DIFF
--- a/src/ng_model_gym/core/config/config_model.py
+++ b/src/ng_model_gym/core/config/config_model.py
@@ -202,6 +202,22 @@ class NFRUModelSettings(PrebuiltModelSettingsBase):
         default_factory=list,
         description="Path substrings identifying legacy NFRU captures that should use the old window stride behavior.",
     )
+    dynamic_mask_is_runtime_accurate: bool = Field(
+        default=False,
+        description=(
+            "Whether to use runtime-accurate dynamic masks "
+            "in NFRU preprocessing and motion-vector warping."
+        ),
+    )
+    mv_similarity_threshold: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Motion-vector similarity threshold used by NFRU dynamic masks. "
+            "Defaults to a value specific to the selected dynamic mask "
+            "implementation."
+        ),
+    )
 
     @field_validator("scale_factor", mode="before")
     @classmethod

--- a/src/ng_model_gym/core/config/schema_config.json
+++ b/src/ng_model_gym/core/config/schema_config.json
@@ -82,6 +82,24 @@
                                 "type": "string"
                             },
                             "type": "array"
+                        },
+                        "dynamic_mask_is_runtime_accurate": {
+                            "default": false,
+                            "description": "Whether to use runtime-accurate dynamic masks in NFRU preprocessing and motion-vector warping.",
+                            "type": "boolean"
+                        },
+                        "mv_similarity_threshold": {
+                            "anyOf": [
+                                {
+                                    "minimum": 0.0,
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "default": null,
+                            "description": "Motion-vector similarity threshold used by NFRU dynamic masks. Defaults to a value specific to the selected dynamic mask implementation."
                         }
                     }
                 ]

--- a/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
+++ b/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
@@ -5,7 +5,9 @@
         "model_source": "prebuilt",
         "version": "1",
         "scale_factor": 2.0,
-        "legacy_nfru_capture_paths": []
+        "legacy_nfru_capture_paths": [],
+        "dynamic_mask_is_runtime_accurate": false,
+        "mv_similarity_threshold": null
     },
     "dataset": {
         "name": "NFRU",

--- a/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
+++ b/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
@@ -47,6 +47,10 @@ _SHADER_DIR = "ng_model_gym.usecases.nfru.model.shaders"
 _SHADER_FILE = "nfru_v1_sa.slang"
 _FLOW_METHOD = "blockmatch_v311"
 _REQUIRED_COLOUR_SPLITS = ("train", "validation", "test")
+_MV_SIMILARITY_THRESHOLD_DYNAMIC_MASK = 0.01
+_MV_SIMILARITY_THRESHOLD_DYNAMIC_MASK_RUNTIME_ACCURATE = 0.3
+_MV_SIMILARITY_NOISE_THRESHOLD_DYNAMIC_MASK = 0.001
+_MV_SIMILARITY_NOISE_THRESHOLD_DYNAMIC_MASK_RUNTIME_ACCURATE = 1.0
 
 m = load_slang_module(_SHADER_DIR, _SHADER_FILE, autograd=True)
 
@@ -115,6 +119,10 @@ class NFRUv1(BaseNGModel):
             device=self.device,
             scale_factor=self.params.model.scale_factor,
             shader_accurate=self.params.processing.shader_accurate,
+            dynamic_mask_is_runtime_accurate=(
+                self.params.model.dynamic_mask_is_runtime_accurate
+            ),
+            mv_similarity_threshold=self.params.model.mv_similarity_threshold,
         )
         self.quant_params = self.network.quant_params
 
@@ -196,12 +204,24 @@ class NFRUv1Core(nn.Module):
         ),
         scale_factor: int = _DEFAULT_SCALE_FACTOR,
         shader_accurate: bool = False,
+        dynamic_mask_is_runtime_accurate: bool = False,
+        mv_similarity_threshold: Optional[float] = None,
     ):
+        """If mv_similarity_threshold isn't supplied, a default will be used."""
         super().__init__()
         self.device = device
         self.flow_method = _FLOW_METHOD
         self.dynamic_flow = True
         self.of_540 = False
+        self.dynamic_mask_is_runtime_accurate = dynamic_mask_is_runtime_accurate
+        self.mv_similarity_threshold = self._get_mv_similarity_threshold(
+            mv_similarity_threshold, dynamic_mask_is_runtime_accurate
+        )
+        self.mv_similarity_noise_threshold = (
+            self._get_default_mv_similarity_noise_threshold(
+                dynamic_mask_is_runtime_accurate
+            )
+        )
         self.shader_accurate = shader_accurate
         self.scale_factor = scale_factor
 
@@ -296,6 +316,9 @@ class NFRUv1Core(nn.Module):
             in_motion_mat_m1p1=motion_mat_tm1,
             in_motion_mat_p1m1=motion_mat_tp1,
             in_timestep=scale,
+            in_dynamic_mask_is_runtime_accurate=self.dynamic_mask_is_runtime_accurate,
+            in_mv_similarity_threshold=self.mv_similarity_threshold,
+            in_mv_similarity_noise_threshold=self.mv_similarity_noise_threshold,
             out_constructors={
                 "out_packed_mv": SlangOutput(
                     shape=(batch, 1, *out_dims),
@@ -462,11 +485,15 @@ class NFRUv1Core(nn.Module):
         dims_540 = [depth_m1.shape[2], depth_m1.shape[3]]
         dims_270 = [flow_xx_f30_xx.shape[2], flow_xx_f30_xx.shape[3]]
 
-        func_dynamic_mask = m.calculate_previous_dynamic_mask
-        in_dynamic_mask = func_dynamic_mask(
+        func_previous_dynamic_mask = self._get_previous_dynamic_mask_fn(
+            self.dynamic_mask_is_runtime_accurate
+        )
+        in_dynamic_mask = func_previous_dynamic_mask(
             tv_depth=depth_m1,
             tv_mv_m1_f30_m3=mv_m1_f30_m3,
             tv_motion_mat_tm1=motion_mat_m3,
+            mv_similarity_threshold=float(self.mv_similarity_threshold),
+            mv_similarity_noise_threshold=float(self.mv_similarity_noise_threshold),
             out_constructors={
                 "tv_dynamic_mask_p1": SlangOutput(
                     shape=depth_m1.shape, device=str(depth_m1.device)
@@ -528,3 +555,34 @@ class NFRUv1Core(nn.Module):
             "coeffs": self.coeff_softmax(learnt_params),
             "output_mfg": output_mfg,
         }
+
+    @staticmethod
+    def _get_previous_dynamic_mask_fn(dynamic_mask_is_runtime_accurate: bool):
+        return (
+            m.calculate_previous_dynamic_mask_runtime_accurate
+            if dynamic_mask_is_runtime_accurate
+            else m.calculate_previous_dynamic_mask
+        )
+
+    @staticmethod
+    def _get_mv_similarity_threshold(
+        configured_mv_similarity_threshold: float,
+        dynamic_mask_is_runtime_accurate: bool,
+    ) -> float:
+        return (
+            configured_mv_similarity_threshold
+            if configured_mv_similarity_threshold is not None
+            else _MV_SIMILARITY_THRESHOLD_DYNAMIC_MASK_RUNTIME_ACCURATE
+            if dynamic_mask_is_runtime_accurate
+            else _MV_SIMILARITY_THRESHOLD_DYNAMIC_MASK
+        )
+
+    @staticmethod
+    def _get_default_mv_similarity_noise_threshold(
+        dynamic_mask_is_runtime_accurate: bool,
+    ) -> float:
+        return (
+            _MV_SIMILARITY_NOISE_THRESHOLD_DYNAMIC_MASK_RUNTIME_ACCURATE
+            if dynamic_mask_is_runtime_accurate
+            else _MV_SIMILARITY_NOISE_THRESHOLD_DYNAMIC_MASK
+        )

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/00_warp_mv.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/00_warp_mv.slang
@@ -12,18 +12,21 @@ import "warp_flow_common";
 // ─────────────────────────────────────────────────────────────────────────────
 // Argument plumbing
 // ─────────────────────────────────────────────────────────────────────────────
-#define WARP_MV_PARAMS(X)                     \
-    X(TensorView<float>, in_depth),           \
-    X(TensorView<float>, in_depth_m1),        \
-    X(TensorView<float>, in_motion),          \
-    X(TensorView<float>, in_dynamic_mask),    \
-    X(TensorView<float>, in_motion_mat_m1p1), \
-    X(TensorView<float>, in_motion_mat_p1m1), \
-    X(no_diff float,     in_timestep),        \
-    X(TensorView<int>,   out_packed_mv),      \
-    X(TensorView<float>, out_dynamic_mask),   \
-    X(TensorView<float>, out_holes_t),        \
-    X(TensorView<float>, out_holes_tm1)       \
+#define WARP_MV_PARAMS(X)                                      \
+    X(TensorView<float>, in_depth),                            \
+    X(TensorView<float>, in_depth_m1),                         \
+    X(TensorView<float>, in_motion),                           \
+    X(TensorView<float>, in_dynamic_mask),                     \
+    X(TensorView<float>, in_motion_mat_m1p1),                  \
+    X(TensorView<float>, in_motion_mat_p1m1),                  \
+    X(no_diff float,     in_timestep),                         \
+    X(no_diff bool,      in_dynamic_mask_is_runtime_accurate), \
+    X(no_diff float,     in_mv_similarity_threshold),          \
+    X(no_diff float,     in_mv_similarity_noise_threshold),    \
+    X(TensorView<int>,   out_packed_mv),                       \
+    X(TensorView<float>, out_dynamic_mask),                    \
+    X(TensorView<float>, out_holes_t),                         \
+    X(TensorView<float>, out_holes_tm1)                        \
 
 #define DECL(type, name) type name
 #define NAME_ONLY(_, name) name
@@ -52,6 +55,9 @@ struct PushConsts {
     float2   _InvOutputDims;
     float    _InvOutputArea;
     float    _Timestep;
+    bool     _DynamicMaskIsRuntimeAccurate;
+    float    _MvSimilarityThreshold;
+    float    _MvSimilarityNoiseThreshold;
 };
 
 
@@ -82,12 +88,15 @@ Globals makeGlobals(WARP_MV_PARAMS(DECL), uint batch)
     const float4x4 motion_mat_p1m1 = tensor_to_float4x4(in_motion_mat_p1m1, batch);
 
     // push constants
-    g.pc._MotionMatM1P1     = motion_mat_m1p1;
-    g.pc._MotionMatP1M1     = motion_mat_p1m1;
-    g.pc._OutputDims        = out_dims;
-    g.pc._InvOutputDims     = rcp(float2(out_dims));
-    g.pc._InvOutputArea     = rcp(float(out_dims.x * out_dims.y));
-    g.pc._Timestep          = in_timestep;
+    g.pc._MotionMatM1P1                  = motion_mat_m1p1;
+    g.pc._MotionMatP1M1                  = motion_mat_p1m1;
+    g.pc._OutputDims                     = out_dims;
+    g.pc._InvOutputDims                  = rcp(float2(out_dims));
+    g.pc._InvOutputArea                  = rcp(float(out_dims.x * out_dims.y));
+    g.pc._Timestep                       = in_timestep;
+    g.pc._DynamicMaskIsRuntimeAccurate = in_dynamic_mask_is_runtime_accurate;
+    g.pc._MvSimilarityThreshold          = in_mv_similarity_threshold;
+    g.pc._MvSimilarityNoiseThreshold     = in_mv_similarity_noise_threshold;
 
     return g;
 }
@@ -192,14 +201,33 @@ public void warp_mv(WARP_MV_PARAMS(DECL))
     // 1 == Invalid vector
     // 0 == Valid vector to scatter
     uint8_t dynamic_mask_m1 = uint8_t(sample_tensor_nearest(g.b._DynamicMask, batch, uint(0), output_pixel).r);
-    uint8_t dynamic_mask_p1 = uint8_t(
-        dynamic_mask(cm_p1_f30_m1, mv_p1_f30_m1, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0
-    );
+
+    float dynamic_mask_p1_value = 0.0;
+
+    if (g.pc._DynamicMaskIsRuntimeAccurate) {
+        dynamic_mask_p1_value =
+            dynamic_mask_runtime_accurate(
+                cm_p1_f30_m1 * float2(g.pc._OutputDims),
+                mv_p1_f30_m1 * float2(g.pc._OutputDims),
+                g.pc._MvSimilarityThreshold,
+                g.pc._MvSimilarityNoiseThreshold
+            );
+    } else {
+        dynamic_mask_p1_value =
+            dynamic_mask(
+                cm_p1_f30_m1,
+                mv_p1_f30_m1,
+                g.pc._MvSimilarityThreshold,
+                g.pc._MvSimilarityNoiseThreshold
+            );
+    }
+
+    uint8_t dynamic_mask_p1 = uint8_t(dynamic_mask_p1_value > 0.0);
 
     // Save dynamic mask to feedback for next set of frames
     WriteDynamicMask(g, batch, output_pixel, dynamic_mask_p1 + uint8_t(cm_p1_f30_m1_mask));
 
-    // Dont scatter invalid mvs
+    // Don't scatter invalid mvs
     if (dynamic_mask_m1 + uint8_t(cm_m1_f30_p1_mask) > 0) return;
 
     // Normalise depth before scattering

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/common.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/common.slang
@@ -114,6 +114,14 @@ float2 quantise(float2 x) {
     return float2(q) / c;
 }
 
+float dynamic_mask_runtime_accurate(float2 a, float2 b, float eps, float tau) {
+    a = quantise(a);
+    b = quantise(b);
+    float diff = length(a - b);
+    float max_len = max(max(length(a), length(b)), tau);
+    return max_len < tau ? 0.0f : float(diff >= eps);
+}
+
 float dynamic_mask(float2 a, float2 b, float eps, float tau)
 {
     float diff = length(a - b);

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/constants.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/constants.slang
@@ -88,13 +88,6 @@
     #define HALF_MIN 0.00006103515625
 #endif
 
-#ifndef MV_SIMILARITY_NOISE_THRESHOLD
-    #define MV_SIMILARITY_NOISE_THRESHOLD 0.001
-#endif
-
-#ifndef MV_SIMILARITY_THRESHOLD
-    #define MV_SIMILARITY_THRESHOLD 0.01
-#endif
 
 #ifndef MAX_VAL
     #define MAX_VAL 1023.0

--- a/src/ng_model_gym/usecases/nfru/model/shaders/sa/slang_only.slang
+++ b/src/ng_model_gym/usecases/nfru/model/shaders/sa/slang_only.slang
@@ -16,6 +16,8 @@ void calculate_previous_dynamic_mask(
     TensorView<float> tv_depth,
     TensorView<float> tv_mv_m1_f30_m3,
     TensorView<float> tv_motion_mat_tm1,
+    no_diff float mv_similarity_threshold,
+    no_diff float mv_similarity_noise_threshold,
     TensorView<float> tv_dynamic_mask_p1,
 )
 {
@@ -39,7 +41,46 @@ void calculate_previous_dynamic_mask(
     float4x4 motion_mat_tm1 = tensor_to_float4x4(tv_motion_mat_tm1, idx.x);
     float mask;
     float2 cm_m1_f30_m3 = CalculateCameraMotion(uv, 1.0f-depth_m1, motion_mat_tm1, mask);
-    float dynamic_mask_m1 = float(dynamic_mask(cm_m1_f30_m3, mv_m1_f30_m3, MV_SIMILARITY_THRESHOLD, MV_SIMILARITY_NOISE_THRESHOLD) > 0.0);
+    float dynamic_mask_m1 = float(dynamic_mask(cm_m1_f30_m3, mv_m1_f30_m3, mv_similarity_threshold, mv_similarity_noise_threshold) > 0.0);
+
+    // Save dynamic mask to feedback for next set of frames
+    tv_dynamic_mask_p1[uint4(idx.x, 0, idx.yz)] = dynamic_mask_m1;
+}
+
+
+[AutoPyBindCUDA]
+[CUDAKernel]
+[NoDiffThis]
+void calculate_previous_dynamic_mask_runtime_accurate(
+    TensorView<float> tv_depth,
+    TensorView<float> tv_mv_m1_f30_m3,
+    TensorView<float> tv_motion_mat_tm1,
+    no_diff float mv_similarity_threshold,
+    no_diff float mv_similarity_noise_threshold,
+    TensorView<float> tv_dynamic_mask_p1,
+)
+{
+    uint tId = (cudaThreadIdx() + cudaBlockIdx() * cudaBlockDim()).x;
+
+    // We Dispatch across `output`'s dimensions
+    uint3 size = tensor_size(tv_depth).xzw; // N C H W -> NHW -> X Z W
+    int H = size.y;
+    int W = size.z;
+    uint3 idx = tensor_idx(tId, size); // N H W
+    if (any(idx >= size)) return;
+
+    float2 uv = float2(idx.yz + 0.5f) * rcp(float2(size.yz));
+
+    float2 mv_m1_f30_m3 = float2(
+        tv_mv_m1_f30_m3[uint4(idx.x, 0, idx.yz)],
+        tv_mv_m1_f30_m3[uint4(idx.x, 1, idx.yz)]
+    )  * float2(size.yz);
+
+    float depth_m1 = tv_depth[uint4(idx.x, 0, idx.yz)];
+    float4x4 motion_mat_tm1 = tensor_to_float4x4(tv_motion_mat_tm1, idx.x);
+    float mask;
+    float2 cm_m1_f30_m3 = CalculateCameraMotion(uv, 1.0f-depth_m1, motion_mat_tm1, mask) * float2(size.yz);
+    float dynamic_mask_m1 = float(dynamic_mask_runtime_accurate(cm_m1_f30_m3, mv_m1_f30_m3, mv_similarity_threshold, mv_similarity_noise_threshold) > 0.0);
 
     // Save dynamic mask to feedback for next set of frames
     tv_dynamic_mask_p1[uint4(idx.x, 0, idx.yz)] = dynamic_mask_m1;

--- a/tests/usecases/nfru/unit/test_nfru_v1_model.py
+++ b/tests/usecases/nfru/unit/test_nfru_v1_model.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import unittest
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 from unittest.mock import Mock
 
 import torch
@@ -15,6 +15,7 @@ from torch import nn
 from ng_model_gym.core.config.config_model import ConfigModel
 from ng_model_gym.core.model import BaseNGModel, create_model
 from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
+from ng_model_gym.usecases.nfru.model.nfru_v1 import m, NFRUv1Core
 from ng_model_gym.usecases.nfru.model.nfru_v1_nn import NFRUAutoEncoder
 from tests.base_gpu_test import BaseGPUMemoryTest
 from tests.testing_utils import create_simple_params
@@ -27,11 +28,19 @@ _OUTPUT_ATOL = 2e-3
 _OUTPUT_RTOL = 1e-3
 _SWAP_COEFF_ATOL = 2e-3
 _SWAP_COEFF_RTOL = 5e-3
+# Minimum difference in comparisons used in dynamic mask tests
+_DYNAMIC_MASK_MIN_DELTA = 1e-6
 
 
 @unittest.skip("NFRU CI/assets disabled for now")
 class TestNFRUV1Model(BaseGPUMemoryTest):
-    """Regression tests for the NFRU v1 model using recorded golden data."""
+    """
+    Regression tests for the NFRU v1 model using recorded golden data.
+
+    The model is implemented in classes NFRUv1 and NFRUv1Core and uses Slang
+    shaders from src/ng_model_gym/usecases/nfru/model/shaders/nfru_v1_sa.slang
+    ("m", below).
+    """
 
     def setUp(self) -> None:
         super().setUp()
@@ -78,7 +87,12 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
         )
 
     def _build_model(
-        self, batch_size: int, autoencoder_state: Dict[str, torch.Tensor]
+        self,
+        batch_size: int,
+        autoencoder_state: Dict[str, torch.Tensor],
+        *,
+        dynamic_mask_is_runtime_accurate: bool = False,
+        mv_similarity_threshold: Optional[float] = None,
     ) -> None:
         """Create a fresh NFRU model instance configured for the given batch size."""
         params = create_simple_params(usecase="nfru")
@@ -86,6 +100,10 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
 
         params_dict["dataset"]["health_check"] = False
         params_dict["train"]["batch_size"] = batch_size
+        params_dict["model"][
+            "dynamic_mask_is_runtime_accurate"
+        ] = dynamic_mask_is_runtime_accurate
+        params_dict["model"]["mv_similarity_threshold"] = mv_similarity_threshold
 
         params = ConfigModel.model_validate(params_dict)
         params.model_train_eval_mode = TrainEvalMode.FP32
@@ -113,7 +131,6 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
         network.flow_method = reference["flow_method"]
         network.scale_factor = int(reference["scale_factor"])
         network.shader_accurate = bool(reference["shader_accurate"])
-        network.new_dynamic_mask = bool(reference.get("new_dynamic_mask", False))
 
     def _prepare_inputs(
         self, reference: Dict[str, torch.Tensor]
@@ -124,6 +141,25 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
             key: tensor.to(self.device) if isinstance(tensor, torch.Tensor) else tensor
             for key, tensor in inputs.items()
         }
+
+    def _forward_with_dynamic_mask_config(
+        self,
+        *,
+        dynamic_mask_is_runtime_accurate: bool,
+        mv_similarity_threshold: Optional[float],
+    ) -> Dict[str, torch.Tensor]:
+        """Run a full forward pass with a specific dynamic-mask configuration."""
+        # Replace any earlier model (e.g., the model built in setUp())
+        self._build_model(
+            batch_size=1,
+            autoencoder_state=self.autoencoder_state,
+            dynamic_mask_is_runtime_accurate=dynamic_mask_is_runtime_accurate,
+            mv_similarity_threshold=mv_similarity_threshold,
+        )
+        inputs = self._prepare_inputs(self.forward_reference)
+        self._reset_rng()
+        with torch.no_grad():
+            return self.model(inputs)
 
     def _reset_rng(self) -> None:
         """Reset CPU and CUDA random number generator state before stochastic forward passes."""
@@ -219,6 +255,50 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
                 rtol=_OUTPUT_RTOL,
                 atol=_OUTPUT_ATOL,
             )
+
+    def test_forward_pass_dynamic_mask_config_affects_output(self) -> None:
+        """
+        Exercise dynamic-mask settings through the full NFRU forward path. We
+        compare two runs of `NFRUv1Core.forward()` against each other. This
+        allows us to use a much lower "delta" value when comparing floating
+        point numbers than we use in other tests here.
+        """
+        zero_threshold_outputs = self._forward_with_dynamic_mask_config(
+            dynamic_mask_is_runtime_accurate=False,
+            mv_similarity_threshold=0.0,
+        )
+        non_zero_threshold_outputs = self._forward_with_dynamic_mask_config(
+            dynamic_mask_is_runtime_accurate=False,
+            mv_similarity_threshold=0.1,
+        )
+        non_zero_threshold_runtime_accurate_outputs = (
+            self._forward_with_dynamic_mask_config(
+                dynamic_mask_is_runtime_accurate=True,
+                mv_similarity_threshold=0.1,
+            )
+        )
+
+        # Check that the structure of the output is the appropriate
+        self._assert_output_shapes(zero_threshold_outputs)
+        self._assert_output_shapes(non_zero_threshold_outputs)
+        self._assert_output_shapes(non_zero_threshold_runtime_accurate_outputs)
+
+        def compare_outputs(
+            first: Dict[str, torch.Tensor], second: Dict[str, torch.Tensor], msg=None
+        ):
+            output_delta = (first["output"] - second["output"]).abs().max().item()
+            self.assertGreater(output_delta, _DYNAMIC_MASK_MIN_DELTA, msg)
+
+        compare_outputs(
+            zero_threshold_outputs,
+            non_zero_threshold_outputs,
+            "changing the similarity threshold does not change the output",
+        )
+        compare_outputs(
+            non_zero_threshold_outputs,
+            non_zero_threshold_runtime_accurate_outputs,
+            "changing the dynamic mask algorithm does not change the output",
+        )
 
     def test_set_neural_network_swaps_autoencoder(self) -> None:
         """Ensure set_neural_network injects the provided module into the forward path."""
@@ -433,3 +513,65 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
             key: value.to(self.device) if isinstance(value, torch.Tensor) else value
             for key, value in state_dict.items()
         }
+
+
+class TestNFRUV1DynamicMaskConfig(unittest.TestCase):
+    """Tests for NFRU dynamic mask configuration."""
+
+    def test_get_previous_dynamic_mask_fn(self) -> None:
+        """
+        Test that the correct previous dynamic mask function is returned for
+        each value of the parameters.
+        """
+        for runtime_accurate, expected_function in [
+            (False, m.calculate_previous_dynamic_mask),
+            (True, m.calculate_previous_dynamic_mask_runtime_accurate),
+        ]:
+            with self.subTest(
+                runtime_accurate=runtime_accurate,
+                expected_function=expected_function,
+            ):
+                self.assertIs(
+                    NFRUv1Core._get_previous_dynamic_mask_fn(runtime_accurate),
+                    expected_function,
+                )
+
+    def test_get_mv_similarity_threshold(self) -> None:
+        """
+        Check default similarity thresholds for different dynamic mask
+        functions and different user-specified thresholds.
+        """
+        for runtime_accurate, configured_threshold, expected_threshold in [
+            (False, None, 0.01),
+            (False, 0.7, 0.7),
+            (True, None, 0.3),
+            (True, 0.8, 0.8),
+        ]:
+            with self.subTest(
+                runtime_accurate=runtime_accurate,
+                configured_threshold=configured_threshold,
+                expected_threshold=expected_threshold,
+            ):
+                self.assertEqual(
+                    NFRUv1Core._get_mv_similarity_threshold(
+                        configured_threshold,
+                        runtime_accurate,
+                    ),
+                    expected_threshold,
+                )
+
+    def test_get_default_mv_similarity_noise_threshold(self) -> None:
+        """
+        Check default noise thresholds for different dynamic mask functions.
+        """
+        for runtime_accurate, expected_threshold in [(False, 0.001), (True, 1.0)]:
+            with self.subTest(
+                runtime_accurate=runtime_accurate,
+                expected_threshold=expected_threshold,
+            ):
+                self.assertEqual(
+                    NFRUv1Core._get_default_mv_similarity_noise_threshold(
+                        runtime_accurate,
+                    ),
+                    expected_threshold,
+                )


### PR DESCRIPTION
This restores the alternative NFRU dynamic mask function removed in an
earlier patch. Two new JSON parameters control NFRU dynamic mask
behavior:
- `dynamic_mask_is_runtime_accurate`: selects which of the two dynamic
  mask functions is in use.
- `mv_similarity_threshold`: controls the motion vector similarity
  threshold parameter used by dynamic masks. Set to null or leave absent
  for a default setting.

Change-Id: If3f60718397a1b7466a050722ec3272b52460def
Signed-off-by: Mark Thurman <mark.thurman@arm.com>
