### PR TITLE
Allow `TestNSSV1AutoEncoder` to run on non-CUDA hardware

### DIFF
--- a/tests/usecases/nss/unit/test_nss_v1_autoencoder.py
+++ b/tests/usecases/nss/unit/test_nss_v1_autoencoder.py
@@ -9,13 +9,12 @@ from ng_model_gym.usecases.nss.model.model_blocks_v1 import (
     AutoEncoderV1,
     get_kpn_prune_indices,
 )
-from tests.base_gpu_test import BaseGPUMemoryTest
 
 _RTOL = 1e-6
 _ATOL = 1e-6
 
 
-class TestNSSV1AutoEncoder(BaseGPUMemoryTest):
+class TestNSSV1AutoEncoder(unittest.TestCase):
     """Tests for the NSS v1 AutoEncoderV1 block."""
 
     def test_output_shapes_for_high_quality_kpn_size(self):


### PR DESCRIPTION
This reverts a change to
`tests/usecases/nss/unit/test_nss_v1_autoencoder.py` in an earlier
patch, where the class was made to descend from `BaseGPUMemoryTest`.
This was added as a precaution but is not necessary for this test.

Change-Id: Icbab72b2c6a92ab9c6128f7b72ed4470e762b751
Signed-off-by: Mark Thurman <mark.thurman@arm.com>
