### PR TITLE
[MLMOD-404] Update docs for NSS v1/tidy generally

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Introduction
 
-**Neural Graphics Model Gym**  is a Python® toolkit for developing real-time Neural Graphics machine learning models.
+**Neural Graphics Model Gym** is a Python® toolkit for developing real-time Neural Graphics machine learning models.
 
 With **Neural Graphics Model Gym** you can train, finetune and evaluate your Neural Graphics models.
 **Neural Graphics Model Gym** also enables you to perform quantization of your model before exporting it to a format compatible with ML extensions for Vulkan® - allowing you to run on the latest mobile devices.
@@ -85,45 +85,47 @@ Basic usage is shown here. More detailed commands can be found in [usage.md](./d
 
 #### Command line usage
 
-List the available model configuration files:
-```bash
-ng-model-gym init --list
-```
-Running `ng-model-gym init` with no arguments also lists model configuration files.
+Most commands use a configuration file and require the following steps:
 
-Generate a JSON configuration file for a model. If no directory path is provided, files are saved to current directory.
-```bash
-ng-model-gym init <model-template> [save_dir]
-```
-This file contains configuration options for the different usage modes (training, evaluation, and exporting) and paths to local datasets. Some entries have placeholder values (e.g. "<...>"). Make sure to replace those with your own settings.
+1. **List model configuration templates:** Each model (NSS, NFRU, etc.) requires a different type of JSON configuration file. These files are initialized from templates. List available templates using this command:
 
-NFRU configurations can be generated with the `nfru` template:
+   ```bash
+   ng-model-gym init --list
+   ```
 
-```bash
-ng-model-gym init nfru [save_dir]
-```
+2. **Generate a model configuration file from a template:** Use a command of the following form. If no directory path is provided, the configuration file will be saved to the current directory.
 
-> **For Windows users:**
->
-> When editing `config.json`, Windows paths must either use forward slashes (`path/to/location`) or escaped backslashes (`path\\to\\location`). Single backslashes (e.g. `path\to\location`) are invalid JSON and will cause a `JSONDecodeError`.
+   ```bash
+   ng-model-gym init <model-template> [save_dir]
+   ```
 
-Use your custom configuration when invoking CLI commands by providing its path with the `--config-path` or `-c` flag as shown below:
+   Example: NSS and NFRU configuration files are created from the `nss` and `nfru` templates. The following commands will create NSS and NFRU configuration files in the current directory:
 
-```bash
-# Perform model training and evaluation
-ng-model-gym --config-path=<path/to/config.json> train
-# Evaluate a previously trained model
-ng-model-gym -c <path/to/config/file> evaluate --model-path=<path/to/model.pt> --model-type=<fp32|qat_int8>
-# Perform quantization aware training (QAT) and evaluation
-ng-model-gym -c <path/to/config/file> qat
-# Export a trained model to VGF file
-ng-model-gym -c <path/to/config/file> export --model-path=<path/to/model.pt> --export-type=<fp32|qat_int8|ptq_int8>
-```
+   ```bash
+   ng-model-gym init nss
+   ng-model-gym init nfru
+   ```
 
-The `--config-path` (or `-c`) flag is **required** when running the `train`, `qat`, `evaluate`, or `export` commands.
-These commands will fail if a valid config file path is not provided.
+3. **Edit your model configuration file:** Configuration files contain paths to local datasets and options for the different usage modes (training, evaluation, and exporting). Some entries initially contain placeholder values (e.g. `<...>`); make sure to replace those with your own settings.
 
-If you would like to view and download the available pre-trained models, use the following commands:
+   > *For Windows users:*
+   >
+   > Paths must either use forward slashes (`path/to/location`) or escaped backslashes (`path\\to\\location`). Single backslashes (e.g. `path\to\location`) are invalid JSON and will cause a `JSONDecodeError`.
+
+4. **Run Model Gym commands:** Provide the path to the configuration file using the `--config-path`/`-c` flag. For example:
+
+   ```bash
+   # Perform model training and evaluation
+   ng-model-gym --config-path=<path/to/config/file> train
+   # Evaluate a previously trained model
+   ng-model-gym -c <path/to/config/file> evaluate --model-path=<path/to/model.pt> --model-type=<fp32|qat_int8>
+   # Perform quantization aware training (QAT) and evaluation
+   ng-model-gym -c <path/to/config/file> qat
+   # Export a trained model to VGF file
+   ng-model-gym -c <path/to/config/file> export --model-path=<path/to/model.pt> --export-type=<fp32|qat_int8|ptq_int8>
+   ```
+
+Pre-trained models can be viewed and downloaded without `--config-path`/`-c`:
 
 ```bash
 # List downloadable models hosted on the configured repositories
@@ -171,7 +173,7 @@ ngmg.do_evaluate(config, trained_model_path, ngmg.TrainEvalMode.FP32)
 ngmg.do_export(config, trained_model_path, export_type=ngmg.ExportType.FP32)
 ```
 
-Jupyter® notebook tutorials on how to use the package, including:
+Jupyter® Notebook tutorials on how to use the package, including:
 * Training
 * Quantization-aware training and exporting
 * Evaluation
@@ -246,7 +248,7 @@ We also support defining custom use cases to group together related models, data
 
 To train the Neural Super Sampling model, you will first need to capture training data from your game engine in the format expected by the model. A [data capture guide for NSS](./docs/nss/nss_data_capture_guide.md) explaining the steps required to capture datasets is available and the expected layout of the dataset can been seen at [nss_dataset_specification.md](./docs/nss/nss_dataset_specification.md). A plugin for Unreal® Engine is also available [here](https://github.com/arm/neural-graphics-data-capture-for-unreal) that can capture datasets for NSS from a game.
 
-For information regarding the types of data to capture for Neural Frame Rate Upscaling and how to convert your captured frames , see [nfru_data_generation.md](./docs/nfru/nfru_data_generation.md).
+For information regarding the types of data to capture for Neural Frame Rate Upscaling and how to convert your captured frames, see [nfru_data_generation.md](./docs/nfru/nfru_data_generation.md).
 
 
 ## Troubleshooting
@@ -280,7 +282,7 @@ Neural Graphics Model Gym is licensed under [Apache License 2.0](LICENSE.md).
 * Ubuntu® is a registered trademark of Canonical.
 * Docker and the Docker logo are trademarks or registered trademarks of Docker, Inc. in the United States and/or other countries. Docker, Inc. and other parties may also have trademark rights in other terms used herein.
 * NVIDIA and the NVIDIA logo are trademarks and/or registered trademarks of NVIDIA Corporation in the U.S. and other countries.
-* “Jupyter” and the Jupyter logos are trademarks or registered trademarks of LF Charities.
+* Jupyter and the Jupyter logos are trademarks or registered trademarks of LF Charities.
 * Vulkan is a registered trademark and the Vulkan SC logo is a trademark of the Khronos Group Inc.
 * Microsoft, Windows are trademarks of the Microsoft group of companies
 * Unreal® is a trademark or registered trademark of Epic Games, Inc. in the United States of America and elsewhere.

--- a/docs/nss/nss_data_capture_guide.md
+++ b/docs/nss/nss_data_capture_guide.md
@@ -22,9 +22,11 @@ SPDX-License-Identifier: Apache-2.0
         * [Ground Truth Motion (4x4 nearest depth)](#ground-truth-motion-4x4-nearest-depth)
         * [Jittered input decimation](#jittered-input-decimation)
         * [Quantized Halton Sequence](#quantized-halton-sequence)
+5. [Trademarks and copyrights](#trademarks-and-copyrights)
 
 
 ## Requirements
+
 Before capturing frames, check the requirements for using NSS in your game. Your game must:
 
 * Have support for jittered rendering.
@@ -33,27 +35,33 @@ Before capturing frames, check the requirements for using NSS in your game. Your
 
 We recommend integrating the [runtime portion of NSS](https://github.com/arm/neural-graphics-sdk-for-game-engines) and verify that it runs correctly before proceeding with fine-tuning.
 
-Locate the point in your engine's rendering pipeline before most post-processing effects are applied. For more information on the correct point in the rendering pipeline, see FidelityFX Super Resolution 2.3.3 (FSR2) | GPUOpen Manuals.
+Locate the point in your engine's rendering pipeline before most post-processing effects are applied. For more information on the correct point in the rendering pipeline, see [the FidelityFX™ Super Resolution 2.3.3 (FSR2) manual](https://gpuopen.com/manuals/fidelityfx_sdk/techniques/super-resolution-temporal/).
+
 
 ## Data Capture Steps
-1. Capture the very-high-resolution (CaptureResolution)  color, motion vector, and depth buffers.
-2. To create the low-resolution (SrcResolution) input frames, pass the color, motion vector, and depth buffers into one or more shaders which decimate and jitter them.
-3. To generate the high-quality (TargetResolution) ground-truth frames, downsample the color as recommended in the [Data Capture Theory](#data-capture-theory) section of this document.
+
+1. Capture the very-high-resolution (`CaptureResolution`) color, motion vector, and depth buffers.
+2. To create the low-resolution (`SrcResolution`) input frames, pass the color, motion vector, and depth buffers into one or more shaders which decimate and jitter them.
+3. To generate the high-quality (`TargetResolution`) ground-truth frames, downsample the color as recommended in the [Data Capture Theory](#data-capture-theory) section of this document.
 4. Save these textures to disk in the layout as defined in the [Dataset Specification](nss_dataset_specification.md). You do not need to continue the rendering pipeline after this step.
 5. After you render the required number of frames, write a JSON file with required metadata. You can see an [example](../../tests/datasets/test_nss_exr/0002.json) in the Neural Graphics Model Gym. If your capturing method used Camera Cuts (or large rotations/translations during a capture sequence), please ensure every frame includes a `CameraCut` boolean so the tooling can split captures into cut-free sequences (see [Annotating Camera Cuts](#annotating-camera-cuts)).
 6. Optionally, to capture frames of a pre-authored sequence, use **Replay** functionality in your game engine to simplify the capture process and make it repeatable.
 
+
 ## Recommendations
+
 ### Sequences
+
 Neural Super Sampling (NSS) is a recurrent model that uses previous predictions and outputs to generate new outputs.
 
-You must train NSS in a recurrent manner. The training input consists of a sequence of t_train consecutive frames. Typically, t_train is set to a value such as 16.
+You must train NSS in a recurrent manner. The training input consists of a sequence of `t_train` consecutive frames. Typically, `t_train` is set to a value such as 16.
 
-To generate the sequences of t_train frames, you must capture frame sequences from your game. The length of these captured sequences are labelled as t_captured, where t_captured > t_train. Once collections of longer sequences have been captured, then the code within the model-gym handles the generation of batches of data of length t_train for the training process.
+To generate the sequences of `t_train` frames, you must capture frame sequences from your game. The length of these captured sequences are labelled as `t_captured`, where `t_captured` > `t_train`. Once collections of longer sequences have been captured, then the code within the model-gym handles the generation of batches of data of length `t_train` for the training process.
 
-We recommend capturing many short sequences of frames from different scenes rather than a few long ones from a single scene. This approach simplifies dataset curation and increases training set diversity - which should help when training NSS. We typically set t_captured to approximately 100
+We recommend capturing many short sequences of frames from different scenes rather than a few long ones from a single scene. This approach simplifies dataset curation and increases training set diversity - which should help when training NSS. We typically set `t_captured` to approximately 100.
 
 ### Annotating Camera Cuts
+
 Camera cuts reset the NSS temporal history. If your method of data capture involves camera cuts in a single capture, you must:
 
 - Set `CameraCut=true` for the first frame of each capture, and for the first frame following any teleport, hard cut, or other discontinuity that invalidates history buffers.
@@ -63,11 +71,14 @@ Camera cuts reset the NSS temporal history. If your method of data capture invol
 The EXR→Safetensors writer copies this metadata into a `camera_cut` tensor, and the NSS dataset loader refuses to emit recurrent windows that cross a flagged frame, dropping sequences which are shorter than `recurrent_samples`.
 
 ### Dataset Size
+
 In general, larger datasets improve machine learning model performance.
 
 * We use a dataset of >50,000 frames, divided into ~300 sequences to **train** Neural Super Sampling (NSS) **from scratch**.
  To **finetune** NSS for your game, ~5,000 frames are required to achieve good results.
+
 ### Types of Content to Capture
+
 When collecting training data for Neural Super Sampling (NSS), we recommend using a wide variety of scenes that reflect the types of content NSS must handle in your game.
 
 Based on our experience developing NSS, we recommend capturing at least the following types of content:
@@ -94,10 +105,14 @@ We recommend that a training dataset is comprised as follows:
 Although we recommend capturing specific types of content, it is most important to collect data that reflects actual gameplay. Ideally, the captured data includes a mix of content, for example, a moving camera, a moving character, particle effects, and complex textures.
 > **NOTE** \
 > If you have identified visual artifacts while using NSS in your game, you must capture the problematic scenes and include them as part of your training set.
+
 ### Check data licensing
+
 When capturing sequences, it is the user's responsibility to ensure licenses on all their assets are legally acceptable for ML training.
 
+
 ## Data Capture Theory
+
 To capture data from a game engine we render each frame, and corresponding Geometry buffer, at native 8k (`7680 × 4320`) resolution, the same 8K textures are then used to construct both the inputs and ground truth frames for Neural Super Sampling training.
 
 Ground truth frames are constructed by downsampling the 8K textures to 1080p. For ground truth color (`ground_truth` image), we apply a 4x4 box filter, to form a 1080p color texture with 16 samples-per-pixel.
@@ -123,7 +138,9 @@ The index is calculated by quantizing a low discrepancy sequence, such as Halton
 This methodology ensures the closest possible attainable sample consistency, as both the input and ground truth are derived from the same source, whilst also maintaining a considerable degree of similarity between the 1 SPP aliased input and typical jittered rendering, which is the expected inference-time input.
 
 ![Jitter Pattern](../figures/jitter_pattern.png)
+
 ### Examples
+
 #### Ground truth color (4x4 box filter)
 
 For ground truth color (`ground_truth` image), we apply a 4x4 box filter, to form a 1080p color texture with 16 samples-per-pixel.
@@ -237,3 +254,8 @@ Vector2 GenerateRandomOffset(int sampleIndex, int quantGridSize = 8)
     return offset;
 }
 ```
+
+
+## Trademarks and copyrights
+
+* AMD FidelityFX™ is a trademark of Advanced Micro Devices, Inc.

--- a/docs/nss/nss_dataset_specification.md
+++ b/docs/nss/nss_dataset_specification.md
@@ -128,12 +128,12 @@ Metadata is split up into two parts "per sequence," which reflects global inform
 | Metadata    | DTYPE  | Description | Requirement |
 | -------- | ------- | ------- | ------- |
 |`Frame` | `int` | Frame index. | Mandatory |
-|`FovX` | `float` | Horizontal Fov of the camera (radians). | Mandatory |
-|`FovY` | `float` | Vertical Fov of the camera (radians). | Mandatory |
+|`FovX` | `float` | Horizontal field of view of the camera (radians). | Mandatory |
+|`FovY` | `float` | Vertical field of view of the camera (radians). | Mandatory |
 |`CameraNearPlane` | `float` | Near plane of the camera in meters. | Mandatory |
 |`CameraFarPlane` | `float` | Far plane in meters from the camera. `-1.0` is used to indicate an infinite far plane.| Mandatory |
-|`ViewProjection` | `list` | ViewProjection matrix's raw data (`float`, column major). | Mandatory |
+|`ViewProjection` | `list` | `ViewProjection` matrix's raw data (`float`, column major). | Mandatory |
 |`Jitter` | `dict` | The frame's raw jitter offset in pixels. e.g., `{"X": 0.25, "Y": 0.67}`. | Mandatory |
-|`NormalizedPerRatioJitter` | `list` | List containing per-upscaling ratio normalized jitter offsets (i.e. NormalizedPerRatioJitter [x2_index] would be the jitter offset used for decimating the textures in the x2 scenario). Normalized jitter values are the `Jitter {-0.5, 0.5}` divided by the SrcRes (i.e 960x540) | Mandatory |
+|`NormalizedPerRatioJitter` | `list` | List containing per-upscaling ratio normalized jitter offsets (i.e. `NormalizedPerRatioJitter` [`x2_index`] would be the jitter offset used for decimating the textures in the x2 scenario). Normalized jitter values are the `Jitter {-0.5, 0.5}` divided by the `SrcRes` (i.e 960x540) | Mandatory |
 |`Exposure` | `float` | Exposure value used in the frame for color correction. | Optional |
 |`CameraCut` | `bool` | `true` when the current frame is the first frame after a camera cut, otherwise `false`. | Optional |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,36 +19,46 @@ ng-model-gym --help
 
 #### Configuration file
 
-Neural Graphics Model Gym is configured using a JSON file, containing all the necessary model parameters and paths to datasets.
+Neural Graphics Model Gym is configured using a JSON file containing all necessary model parameters and paths to datasets. This file is initialized from a configuration template appropriate to the model in use.
 
-To list the available configuration templates, run:
+To list configuration templates, run:
 ```bash
 ng-model-gym init --list
+# Or simply: ng-model-gym init
 ```
-Running `ng-model-gym init` with no arguments also lists templates.
 
-The standard templates include `nss` and `nfru`.
+Standard templates include `nss` and `nfru`; these relate to Model Gym's NSS and NFRU models.
 
-To generate a configuration file, run:
+To generate a configuration file from a template, use a command of this form:
 ```bash
-ng-model-gym init <model-template> [save_dir]
+ng-model-gym init <configuration-template> [save_dir]
+
+# e.g.
+# - Generate an NSS configuration file in the current directory:
+ng-model-gym init nss
+# - Generate an NFRU configuration file in a "config-dir" subdirectory:
+ng-model-gym init nfru config-dir
 ```
 
 This command creates two files in the selected output directory (or your working directory if path is omitted):
 
-- `<model-name>.json`
-    - Template populated with default values. Some entries have placeholder values (e.g. "<...>"). Make sure to replace those with your own settings. Dataset paths are expected to be folders containing datasets, not individual files.
+- `<model-name>_config.json`
+  - Template populated with default values. Some entries have placeholder values (e.g. "<...>"). Make sure to replace those with your own settings. Dataset paths are expected to be folders containing datasets, not individual files.
 
 - `schema_config.json`
   -  An accompanying file detailing all available configuration parameters
 
-NFRU configuration files can be generated with:
+Edit `<model-name>_config.json` to customize Model Gym's behavior.
 
-```bash
-ng-model-gym init nfru [save_dir]
-```
+> *Example:*
+>
+> The NSS model accepts a "quality" setting in its `nss_config.json` file. This provides different compromises between speed and output quality:
+>
+> - "high": slowest but best-quality option. Checks the current frame and depth/motion detail more thoroughly, uses a larger image filter for clean-up, and samples previous frames more accurately.
+> - "low": fastest but lowest-quality option. Uses lighter current-frame and depth/motion checks, and samples previous frames less accurately. May show more flicker or motion artifacts around fine detail and moving objects.
+> - "mid": balanced option. Similar to “low” but samples previous frames more accurately, like “high”.
 
-Use your custom configuration when invoking CLI commands by providing its path with the `--config-path` or `-c` flag as shown below:
+Use your custom configuration when invoking CLI commands by providing its path with the `--config-path` or `-c` flag, as shown below:
 
 ```bash
 ng-model-gym --config-path=<path/to/model_config.json> train
@@ -192,7 +202,7 @@ ng-model-gym -c <path/to/config/file> export --model-path=@<repo_name>/<filename
 ng-model-gym -c <path/to/config/file> export --model-path=@neural-super-sampling/nss_v0.1.0_fp32.pt --export-type=fp32
 ```
 
-Ensure you select an export-type of fp32, qat_int8, or ptq_int8 with `--export-type`. Only QAT trained models can be exported to qat_int8.
+Ensure you select an export-type of `fp32`, `qat_int8`, or `ptq_int8` with `--export-type`. Only QAT trained models can be exported to `qat_int8`.
 
 The configuration file specifies the output directory for the generated VGF file.
 


### PR DESCRIPTION
`README.md`: Divide main summarized instructions into clearer steps.
Give explicit instructions for generating NSS configuration files.

`docs/usage.md`: Give similar explicit instructions for generating NSS
configuration files. Mention configuration of NSS v1 quality levels.

`docs/nss/nss_data_capture_guide.md`: Add trademarks section, consistent
with other documents. Use blank lines more consistently.

General: More consistently surround identifiers with backticks.

Change-Id: I28a6d69d6d7e80af34c1c182c0abe3ac2c2a1e98
Signed-off-by: Mark Thurman <mark.thurman@arm.com>
