### PR TITLE
MLMOD-456 Latest NSSv1 upgrades

### DIFF
--- a/src/ng_model_gym/core/config/config_model.py
+++ b/src/ng_model_gym/core/config/config_model.py
@@ -197,6 +197,20 @@ class NSSModelSettings(PrebuiltModelSettingsBase):
         default=None,
         description=("NSS v1 quality mode."),
     )
+    nss_v1_luma_derivative: bool = Field(
+        default=True,
+        description=(
+            "Enable NSS v1 luminance-derivative features in shader-accurate "
+            "preprocessing. Disable to evaluate the alternate runtime variant."
+        ),
+    )
+    nss_v1_sharp_theta: bool = Field(
+        default=True,
+        description=(
+            "Enable NSS v1 sharp-theta weighting in shader-accurate "
+            "postprocessing. Disable to evaluate the alternate runtime variant."
+        ),
+    )
     normalize_lr_motion: Optional[bool] = Field(
         default=None,
         description=(

--- a/src/ng_model_gym/core/config/schema_config.json
+++ b/src/ng_model_gym/core/config/schema_config.json
@@ -63,6 +63,16 @@
                             "default": null,
                             "description": "NSS v1 quality mode."
                         },
+                        "nss_v1_luma_derivative": {
+                            "default": true,
+                            "description": "Enable NSS v1 luminance-derivative features in shader-accurate preprocessing. Disable to evaluate the alternate runtime variant.",
+                            "type": "boolean"
+                        },
+                        "nss_v1_sharp_theta": {
+                            "default": true,
+                            "description": "Enable NSS v1 sharp-theta weighting in shader-accurate postprocessing. Disable to evaluate the alternate runtime variant.",
+                            "type": "boolean"
+                        },
                         "normalize_lr_motion": {
                             "anyOf": [
                                 {

--- a/src/ng_model_gym/usecases/nss/configs/nss_v1_template.json
+++ b/src/ng_model_gym/usecases/nss/configs/nss_v1_template.json
@@ -7,6 +7,8 @@
         "scale": 2.0,
         "recurrent_samples": 16,
         "quality": "high",
+        "nss_v1_luma_derivative": true,
+        "nss_v1_sharp_theta": true,
         "normalize_lr_motion": false,
         "gt_history_augmentation": true,
         "gt_history_augmentation_chance": 30.0

--- a/src/ng_model_gym/usecases/nss/model/model_v1.py
+++ b/src/ng_model_gym/usecases/nss/model/model_v1.py
@@ -55,6 +55,8 @@ class NSSV1Model(BaseNGModel):
             raise TypeError(
                 "model section in parameter is not of type NSSModelSettings"
             )
+        if not self.params.processing.shader_accurate:
+            raise ValueError("NSS-v1 requires processing.shader_accurate=True.")
 
         self.quality = resolve_nss_v1_quality(self.params.model.quality)
         quality_settings = NSSV1QualitySettings.preset(self.quality)
@@ -72,7 +74,6 @@ class NSSV1Model(BaseNGModel):
 
         # NSS v1 training and evaluation configs use shader-accurate NSS with
         # low-resolution motion vectors.
-        self.shader_accurate = True
         self.slang_shader_dir = "ng_model_gym.usecases.nss.model.shaders"
         self.slang_shader_file = "nss_v1.slang"
         self.slang: Optional[object] = None
@@ -84,22 +85,21 @@ class NSSV1Model(BaseNGModel):
         self.use_sparse_filter_2x2 = quality_settings.use_sparse_filter_2x2
         self.use_history_catmull = quality_settings.use_history_catmull
         self.packed_nearest_offset_quad = quality_settings.packed_nearest_offset_quad
-        self.nss_v1_luma_derivative = True
-        self.nss_v1_sharp_theta = True
+        self.nss_v1_luma_derivative = bool(self.params.model.nss_v1_luma_derivative)
+        self.nss_v1_low_mid_luma_derivative = bool(
+            quality_settings.low_mid_luma_derivative and self.nss_v1_luma_derivative
+        )
+        self.nss_v1_sharp_theta = bool(self.params.model.nss_v1_sharp_theta)
         self.required_multiple = (8, 8)
         self.filter_kernel_size = quality_settings.filter_kernel_size
         self.filter_kernel_taps = self.filter_kernel_size * self.filter_kernel_size
-        self.effective_shader_accurate = (
-            self.shader_accurate or self.preprocess_half_res_input
-        )
-        if self.effective_shader_accurate and self.params.model.normalize_lr_motion:
+        if self.params.model.normalize_lr_motion:
             raise ValueError(
-                "NSS-v1 shader-accurate or half-resolution quality modes require "
-                "model.normalize_lr_motion=False to preserve low-resolution motion "
-                "vectors."
+                "NSS-v1 requires model.normalize_lr_motion=False to preserve "
+                "low-resolution motion vectors."
             )
 
-        self.motion_key = "motion_lr" if self.effective_shader_accurate else "motion"
+        self.motion_key = "motion_lr"
 
         self._lut_in_shape: Optional[tuple[int, int, int, int]] = None
         self._lut_out_shape: Optional[tuple[int, int, int, int]] = None
@@ -224,6 +224,25 @@ class NSSV1Model(BaseNGModel):
             dispatch_size=[depth_shape[0], depth_shape[2], depth_shape[3]],
         )
 
+        if self.preprocess_half_res_input and self.depth_scatter_quarter_res_input:
+            disocclusion_mask_lq = slang.lq_disocclusion_mask(
+                in_motion=preprocess_input[self.motion_key],
+                in_depth=preprocess_input["depth"],
+                in_depth_tm1=depth_tm1,
+                in_depth_params=preprocess_input["depth_params"],
+                in_render_size=preprocess_input["render_size"],
+                out_constructors={
+                    "out_disocclusion_mask": SlangOutput(
+                        shape=depth_shape,
+                        channel_dim=1,
+                        device=device,
+                    ),
+                },
+                dispatch_size=[depth_shape[0], depth_shape[2], depth_shape[3]],
+            )
+        else:
+            disocclusion_mask_lq = preprocess_input["depth"]
+
         derivative_shape = pad_shape if self.preprocess_half_res_input else input_shape
         nearest_offset_shape = (
             pad_shape if self.preprocess_half_res_input else process_shape
@@ -234,6 +253,7 @@ class NSSV1Model(BaseNGModel):
             "in_motion": preprocess_input[self.motion_key],
             "in_depth": preprocess_input["depth"],
             "in_depth_tm1": depth_tm1,
+            "in_disocclusion_mask_lq": disocclusion_mask_lq,
             "in_jitter": preprocess_input["jitter"],
             "in_jitter_tm1": preprocess_input["jitter_tm1"],
             "in_feedback_tm1": preprocess_input["temporal_params_tm1"],
@@ -695,10 +715,13 @@ class NSSV1Model(BaseNGModel):
                 "NSS_PACKED_NEAREST_OFFSET_QUAD": int(self.packed_nearest_offset_quad),
                 "FILTER_COLOR_KERNEL_SZ": int(self.filter_kernel_taps),
                 "NSS_V1_LUMA_DERIVATIVE": int(self.nss_v1_luma_derivative),
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": int(
+                    self.nss_v1_low_mid_luma_derivative
+                ),
                 "NSS_V1_SHARP_THETA": int(self.nss_v1_sharp_theta),
+                # NSS v1 always uses the shader-accurate Slang variant at runtime.
+                "SHADER_ACCURATE": True,
             }
-            if self.effective_shader_accurate:
-                slang_defines["SHADER_ACCURATE"] = True
             self.slang = load_slang_module(
                 self.slang_shader_dir,
                 self.slang_shader_file,

--- a/src/ng_model_gym/usecases/nss/model/quality_modes.py
+++ b/src/ng_model_gym/usecases/nss/model/quality_modes.py
@@ -59,6 +59,7 @@ class NSSV1QualitySettings:
     use_sparse_filter_2x2: bool
     use_history_catmull: bool
     packed_nearest_offset_quad: bool
+    low_mid_luma_derivative: bool
     kpn_size: Tuple[int, int]
     filter_kernel_size: int
 
@@ -77,6 +78,7 @@ class NSSV1QualitySettings:
                 use_sparse_filter_2x2=True,
                 use_history_catmull=False,
                 packed_nearest_offset_quad=True,
+                low_mid_luma_derivative=True,
                 kpn_size=(4, 4),
                 filter_kernel_size=2,
             )
@@ -89,6 +91,7 @@ class NSSV1QualitySettings:
                 use_sparse_filter_2x2=True,
                 use_history_catmull=True,
                 packed_nearest_offset_quad=True,
+                low_mid_luma_derivative=True,
                 kpn_size=(4, 4),
                 filter_kernel_size=2,
             )
@@ -102,6 +105,7 @@ class NSSV1QualitySettings:
             use_sparse_filter_2x2=False,
             use_history_catmull=True,
             packed_nearest_offset_quad=False,
+            low_mid_luma_derivative=False,
             kpn_size=(6, 6),
             filter_kernel_size=3,
         )

--- a/src/ng_model_gym/usecases/nss/model/shaders/nss_v1.slang
+++ b/src/ng_model_gym/usecases/nss/model/shaders/nss_v1.slang
@@ -38,6 +38,9 @@
 #ifndef NSS_V1_LUMA_DERIVATIVE
 #define NSS_V1_LUMA_DERIVATIVE 1
 #endif // !NSS_V1_LUMA_DERIVATIVE
+#ifndef NSS_V1_LOW_MID_LUMA_DERIVATIVE
+#define NSS_V1_LOW_MID_LUMA_DERIVATIVE (NSS_V1_LUMA_DERIVATIVE && (NSS_QUALITY_IS_LOW || NSS_QUALITY_IS_MID))
+#endif // !NSS_V1_LOW_MID_LUMA_DERIVATIVE
 #ifndef NSS_V1_SHARP_THETA
 #define NSS_V1_SHARP_THETA 1
 #endif // !NSS_V1_SHARP_THETA
@@ -49,5 +52,6 @@
 #endif // !SHADER_ACCURATE
 
 import "nss_v1/depth_scatter";
+import "nss_v1/disocclusion_lq";
 import "nss_v1/pre_process";
 import "nss_v1/post_process";

--- a/src/ng_model_gym/usecases/nss/model/shaders/nss_v1/depth_scatter.slang
+++ b/src/ng_model_gym/usecases/nss/model/shaders/nss_v1/depth_scatter.slang
@@ -155,7 +155,11 @@ public void depth_scatter(DEPTH_SCATTER_PARAMS(DECL))
 
     float depth_dilated = result.z;
     float2 motion = result.xy * g.pc._InvScale;
+#if NSS_DEPTH_SCATTER_QUARTER_RES_INPUT
+    motion *= float(length(result.xy) > 0.1f);
+#else
     motion *= float(length(motion) > 0.1f);
+#endif // NSS_DEPTH_SCATTER_QUARTER_RES_INPUT
     motion *= g.pc._InvOutputDims;
 
     float2 reproj_uv = uv - motion;

--- a/src/ng_model_gym/usecases/nss/model/shaders/nss_v1/disocclusion_lq.slang
+++ b/src/ng_model_gym/usecases/nss/model/shaders/nss_v1/disocclusion_lq.slang
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: Copyright 2026 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-License-Identifier: Apache-2.0
+
+import "../../../../common/model/shaders/depth_clip";
+import "../../../../common/model/shaders/tensor";
+
+#define LQ_DISOCCLUSION_MOTION_THRESHOLD 0.1f
+#ifndef NSS_LQ_DISOCCLUSION_DEPTH_GRADIENT_TOLERANCE_SCALE
+#define NSS_LQ_DISOCCLUSION_DEPTH_GRADIENT_TOLERANCE_SCALE 1.0f
+#endif // !NSS_LQ_DISOCCLUSION_DEPTH_GRADIENT_TOLERANCE_SCALE
+
+#define LQ_DISOCCLUSION_PARAMS(X)          \
+    X(TensorView<float>, in_motion),       \
+    X(TensorView<float>, in_depth),        \
+    X(TensorView<int>,   in_depth_tm1),    \
+    X(TensorView<float>, in_depth_params), \
+    X(TensorView<float>, in_render_size),  \
+    X(TensorView<float>, out_disocclusion_mask)
+
+#define LQ_DECL(type, name) type name
+#define LQ_NAME_ONLY(_, name) name
+#define LQ_DISOCCLUSION_ARGS LQ_DISOCCLUSION_PARAMS(LQ_NAME_ONLY)
+
+
+[NoDiffThis]
+inline bool LqDisocclusionIsOnScreen(int2 pos, int2 size)
+{
+    return all(pos >= int2(0)) && all(pos < size);
+}
+
+
+[NoDiffThis]
+inline int2 LqDisocclusionClampToSize(int2 pos, int2 size)
+{
+    return clamp(pos, int2(0), size - 1);
+}
+
+
+[NoDiffThis]
+inline void LqDisocclusionFindDepthMotion4x4(
+    TensorView<float> in_motion,
+    TensorView<float> in_depth,
+    uint batch,
+    int2 dst_pos,
+    int2 dst_size,
+    float4 device_to_view,
+    out float closest_depth,
+    out float2 closest_motion,
+    out float local_view_depth_range)
+{
+    int2 depth_size = int2(tensor_size(in_depth).zw);
+    int2 src_base = int2(float2(dst_pos) * (float2(depth_size) / float2(dst_size)));
+    int2 src_pos = LqDisocclusionClampToSize(src_base, depth_size);
+
+    closest_depth = in_depth[uint4(batch, 0, uint2(src_pos))];
+    float src_view_depth = GetViewSpaceDepth(closest_depth, device_to_view);
+    float min_view_depth = src_view_depth;
+    float max_view_depth = src_view_depth;
+    closest_motion = float2(
+        in_motion[uint4(batch, 0, uint2(src_pos))],
+        in_motion[uint4(batch, 1, uint2(src_pos))]
+    );
+
+    for (int y = 0; y < 4; ++y) {
+        for (int x = 0; x < 4; ++x) {
+            int2 sample_pos = src_base + int2(x, y);
+            if (LqDisocclusionIsOnScreen(sample_pos, depth_size)) {
+                float sample_depth = in_depth[uint4(batch, 0, uint2(sample_pos))];
+                float sample_view_depth = GetViewSpaceDepth(sample_depth, device_to_view);
+                min_view_depth = min(min_view_depth, sample_view_depth);
+                max_view_depth = max(max_view_depth, sample_view_depth);
+                if (sample_depth < closest_depth) {
+                    closest_depth = sample_depth;
+                    closest_motion = float2(
+                        in_motion[uint4(batch, 0, uint2(sample_pos))],
+                        in_motion[uint4(batch, 1, uint2(sample_pos))]
+                    );
+                }
+            }
+        }
+    }
+
+    local_view_depth_range = max_view_depth - min_view_depth;
+}
+
+
+[NoDiffThis]
+inline float2 LqDisocclusionMotionToDepthPixels(float2 motion_pixels, int2 input_size, int2 depth_size)
+{
+    float2 motion_depth_pixels = motion_pixels * (float2(depth_size) / float2(input_size));
+    return motion_depth_pixels * float(length(motion_pixels) > LQ_DISOCCLUSION_MOTION_THRESHOLD);
+}
+
+
+[NoDiffThis]
+inline float LqDisocclusionComputeDepthClip(
+    TensorView<int> depth_tm1,
+    uint batch,
+    float2 uv,
+    float2 render_size,
+    float current_depth,
+    float4 device_to_view,
+    float local_view_depth_range,
+    float bilinear_weight_threshold = 0.1f)
+{
+    float2 depth_tm1_size = tensor_size(depth_tm1).zw;
+    float current_view_depth = GetViewSpaceDepth(current_depth, device_to_view);
+    BilinearSamplingData bilinear_info = GetBilinearSamplingData(
+        uv,
+        uint2(depth_tm1_size)
+    );
+    float local_depth_tolerance =
+        local_view_depth_range * NSS_LQ_DISOCCLUSION_DEPTH_GRADIENT_TOLERANCE_SCALE;
+
+    float depth = 0.0f;
+    float weight_sum = 0.0f;
+    for (int sample_index = 0; sample_index < 4; sample_index++) {
+        const int2 offset = bilinear_info.iOffsets[sample_index];
+        const int2 sample_pos = bilinear_info.iBasePos + offset;
+        const float weight = bilinear_info.fWeights[sample_index];
+        const bool onscreen = IsOnScreen(sample_pos, uint2(depth_tm1_size));
+        weight_sum += onscreen ? 0.0f : weight;
+
+        if (onscreen && weight > bilinear_weight_threshold) {
+            const float prev_depth =
+                float(depth_tm1[uint4(batch, 0, sample_pos)]) * rcp(float(0x7FFFFFFF));
+            const float prev_view_depth = GetViewSpaceDepth(prev_depth, device_to_view);
+            const float depth_diff = current_view_depth - prev_view_depth;
+
+            if (depth_diff > 0.0f) {
+                const float plane_depth = max(prev_depth, current_depth);
+                const float3 center = GetViewSpacePosition(
+                    int2(render_size * 0.5f),
+                    int2(render_size),
+                    plane_depth,
+                    device_to_view
+                );
+                const float3 corner = GetViewSpacePosition(
+                    int2(0, 0),
+                    int2(render_size),
+                    plane_depth,
+                    device_to_view
+                );
+                const float half_viewport_width = length(float2(render_size));
+                const float depth_threshold = max(current_view_depth, prev_view_depth);
+                const float required_sep =
+                    (1.37e-05f * (length(corner) / length(center)) * half_viewport_width * depth_threshold)
+                    + local_depth_tolerance;
+                const float resolution_factor = saturate(
+                    length(float2(render_size)) / length(float2(1080.0f, 1920.0f))
+                );
+                const float power = lerp(1.0f, 3.0f, resolution_factor);
+                depth += pow(saturate(float(required_sep / depth_diff)), power) * weight;
+                weight_sum += weight;
+            }
+        }
+    }
+
+    return (weight_sum > 0.0f) ? saturate(1.0f - depth / weight_sum) : 0.0f;
+}
+
+
+[AutoPyBindCUDA]
+[CUDAKernel]
+[NoDiffThis]
+public void lq_disocclusion_mask(LQ_DISOCCLUSION_PARAMS(LQ_DECL))
+{
+    uint tId = (cudaThreadIdx() + cudaBlockIdx() * cudaBlockDim()).x;
+    uint3 size = tensor_size(out_disocclusion_mask).xzw;
+    uint3 idx = tensor_idx(tId, size);
+    if (any(idx >= size)) return;
+
+    int2 depth_size = int2(tensor_size(out_disocclusion_mask).zw);
+    int2 input_size = int2(tensor_size(in_depth).zw);
+    float2 inv_depth_size = rcp(float2(depth_size));
+    float2 uv = (float2(idx.yz) + 0.5f) * inv_depth_size;
+    float4 device_to_view = float4(
+        in_depth_params[uint4(idx.x, 0, 0, 0)],
+        in_depth_params[uint4(idx.x, 1, 0, 0)],
+        in_depth_params[uint4(idx.x, 2, 0, 0)],
+        in_depth_params[uint4(idx.x, 3, 0, 0)]
+    );
+    float2 render_size = float2(
+        in_render_size[uint4(idx.x, 0, 0, 0)],
+        in_render_size[uint4(idx.x, 1, 0, 0)]
+    );
+
+    float current_depth;
+    float2 motion;
+    float local_view_depth_range;
+    LqDisocclusionFindDepthMotion4x4(
+        in_motion,
+        in_depth,
+        idx.x,
+        int2(idx.yz),
+        depth_size,
+        device_to_view,
+        current_depth,
+        motion,
+        local_view_depth_range
+    );
+
+    float2 motion_depth_pixels = LqDisocclusionMotionToDepthPixels(
+        motion,
+        input_size,
+        depth_size
+    );
+    float2 reproj_uv = uv - (motion_depth_pixels * inv_depth_size);
+
+    out_disocclusion_mask[uint4(idx.x, 0, idx.yz)] = LqDisocclusionComputeDepthClip(
+        in_depth_tm1,
+        idx.x,
+        reproj_uv,
+        render_size,
+        current_depth,
+        device_to_view,
+        local_view_depth_range
+    );
+}
+
+#undef LQ_DISOCCLUSION_ARGS
+#undef LQ_NAME_ONLY
+#undef LQ_DECL
+#undef LQ_DISOCCLUSION_PARAMS

--- a/src/ng_model_gym/usecases/nss/model/shaders/nss_v1/pre_process.slang
+++ b/src/ng_model_gym/usecases/nss/model/shaders/nss_v1/pre_process.slang
@@ -16,6 +16,9 @@ import "nss_common";
 #ifndef NSS_V1_LUMA_DERIVATIVE
 #define NSS_V1_LUMA_DERIVATIVE 1
 #endif // !NSS_V1_LUMA_DERIVATIVE
+#ifndef NSS_V1_LOW_MID_LUMA_DERIVATIVE
+#define NSS_V1_LOW_MID_LUMA_DERIVATIVE 0
+#endif // !NSS_V1_LOW_MID_LUMA_DERIVATIVE
 
 #define EPS 1e-7
 #define DEPTH_SCALE 2147483647.0
@@ -43,6 +46,7 @@ inline bool IsOnScreen(int2 pos, int2 size)
     X(TensorView<float>, in_motion),            \
     X(TensorView<float>, in_depth),             \
     X(TensorView<int>,  in_depth_tm1),          \
+    X(TensorView<float>, in_disocclusion_mask_lq),\
     X(TensorView<float>, in_jitter),            \
     X(TensorView<float>, in_jitter_tm1),        \
     X(DiffTensorView,   in_feedback_tm1),       \
@@ -67,6 +71,7 @@ struct Bindings {
     DiffTensorView _HistoryTex;
     DiffTensorView _FeedbackTensor;
     TensorView<int> _DepthTm1Tex;
+    TensorView<float> _DisocclusionMaskLQTex;
     TensorView<float> _LumaDerivTm1Tex;
 
     DiffTensorView _InputTensor;
@@ -124,6 +129,7 @@ Globals makeGlobals(PREPROCESS_PARAMS(DECL), uint batch)
     g.b._HistoryTex = in_history;
     g.b._FeedbackTensor = in_feedback_tm1;
     g.b._DepthTm1Tex = in_depth_tm1;
+    g.b._DisocclusionMaskLQTex = in_disocclusion_mask_lq;
     g.b._LumaDerivTm1Tex = in_derivative_tm1;
     g.b._InputTensor = out_tensor;
     g.b._LumaDeriv = out_luma_derivative;
@@ -198,40 +204,6 @@ int ReflectIndex(int coord, int size)
 int2 ReflectIndex(int2 coord, int2 size)
 {
     return int2(ReflectIndex(coord.x, size.x), ReflectIndex(coord.y, size.y));
-}
-
-
-[NoDiffThis]
-inline float GetViewSpaceDepth(float depth, float4 device_to_view)
-{
-    return device_to_view.y / (depth - device_to_view.x);
-}
-
-
-[NoDiffThis]
-inline float ComputeDepthClipRequiredSepScale(Globals g)
-{
-    float half_viewport = length(g.pc._RenderSize);
-    float resolution_factor = clamp(
-        half_viewport / length(float2(1080.0f, 1920.0f)),
-        0.0f,
-        1.0f
-    );
-    float3 corner_view_dir = float3(-g.pc._DeviceToViewDepth.z, g.pc._DeviceToViewDepth.w, 1.0f);
-    return 1.37e-05f * length(corner_view_dir) * half_viewport;
-}
-
-
-[NoDiffThis]
-inline float ComputeDepthClipPower(Globals g)
-{
-    float half_viewport = length(g.pc._RenderSize);
-    float resolution_factor = clamp(
-        half_viewport / length(float2(1080.0f, 1920.0f)),
-        0.0f,
-        1.0f
-    );
-    return 1.0f + 2.0f * resolution_factor;
 }
 
 
@@ -364,6 +336,65 @@ inline float3 WarpHistory(Globals g, uint b, float2 uv)
 }
 
 
+struct PreProcessLaneData
+{
+    int2 input_coord;
+    int2 nearest_offset;
+    float depth_dilated;
+    float2 motion;
+    float2 uv;
+    float2 reproj_uv;
+};
+
+
+[Differentiable]
+inline PreProcessLaneData BuildPreProcessLaneData(Globals g, uint b, int2 input_coord)
+{
+    PreProcessLaneData lane;
+    lane.input_coord = clamp(input_coord, int2(0), g.pc._InputDims - 1);
+    lane.uv = (float2(lane.input_coord) + 0.5f) * g.pc._InvInputDims;
+
+    uint2 nearest_coord = uint2(0);
+    lane.nearest_offset = int2(0);
+    lane.depth_dilated = 0.0f;
+    FindNearestDepth_4x4_FromPixel(
+        g,
+        b,
+        lane.input_coord,
+        lane.depth_dilated,
+        nearest_coord,
+        lane.nearest_offset
+    );
+
+    int2 nearest_input_coord = clamp(
+        lane.input_coord + lane.nearest_offset,
+        int2(0),
+        g.pc._InputDims - 1
+    );
+    lane.motion = LoadMotionAtPixel(g, b, nearest_input_coord);
+    lane.reproj_uv = lane.uv - (lane.motion * g.pc._InvInputDims);
+    return lane;
+}
+
+
+[Differentiable]
+inline float3 AverageWarpedHistory2x2(
+    Globals g,
+    uint b,
+    PreProcessLaneData lane_00,
+    PreProcessLaneData lane_10,
+    PreProcessLaneData lane_01,
+    PreProcessLaneData lane_11)
+{
+    return (
+        WarpHistory(g, b, lane_00.reproj_uv) +
+        WarpHistory(g, b, lane_10.reproj_uv) +
+        WarpHistory(g, b, lane_01.reproj_uv) +
+        WarpHistory(g, b, lane_11.reproj_uv)
+    ) * 0.25f;
+}
+
+
 [Differentiable]
 inline float4 WarpFeedback(Globals g, uint b, float2 uv, float disocclusion_mask)
 {
@@ -394,6 +425,13 @@ inline int2 ProcessCoordToInputCoord(Globals g, int2 process_coord)
 
 
 [NoDiffThis]
+inline int2 HalfResProcessCoordToBaseInputCoord(Globals g, int2 process_coord)
+{
+    return clamp(process_coord * 2, int2(0), g.pc._InputDims - 1);
+}
+
+
+[NoDiffThis]
 inline int2 InputCoordToDepthCoord(Globals g, int2 input_coord)
 {
     int2 depth_size = int2(round(rcp(max(g.pc._InvDepthTm1Dims, float2(EPS)))));
@@ -413,69 +451,22 @@ inline float2 MotionToPaddedUvDelta(Globals g, float2 motion)
 }
 
 
-[NoDiffThis]
-inline float2 DerivativeSampleUv(Globals g, float2 uv)
-{
-    return uv * (float2(g.pc._OutputDims) * g.pc._InvPaddedDims);
-}
-
-
 [Differentiable]
-inline float ComputeDisocclusion(Globals g, uint b, float2 reproj_270p_uv, float depth_dilated, bool inverted_depth)
+inline float ComputeDisocclusion(
+    Globals g,
+    uint b,
+    float2 disocclusion_uv,
+    float depth_dilated,
+    bool inverted_depth)
 {
 #if NSS_PREPROCESS_HALF_RES_INPUT
-    const float bilinear_weight_threshold = 0.1f;
-    int2 depth_tm1_size = int2(round(rcp(max(g.pc._InvDepthTm1Dims, float2(EPS)))));
-    float current_view_depth = no_diff(GetViewSpaceDepth(depth_dilated, g.pc._DeviceToViewDepth));
-    float2 sample_px = (reproj_270p_uv * float2(depth_tm1_size)) - 0.5f;
-    int2 sample_base = int2(floor(sample_px));
-    float2 sample_frac = frac(sample_px);
-
-    float w00 = (1.0f - sample_frac.x) * (1.0f - sample_frac.y);
-    float w10 = sample_frac.x * (1.0f - sample_frac.y);
-    float w01 = (1.0f - sample_frac.x) * sample_frac.y;
-    float w11 = sample_frac.x * sample_frac.y;
-
-    float required_sep_scale = no_diff(ComputeDepthClipRequiredSepScale(g));
-    float depth_clip_power = no_diff(ComputeDepthClipPower(g));
-
-    float fDepth = 0.0f;
-    float fWeightSum = 0.0f;
-
-    #define NSS_DEPTH_CLIP_SAMPLE_BLOCK(OFF_X, OFF_Y, WEIGHT)                                                  \
-        {                                                                                                       \
-            int2 sample_pos = sample_base + int2((OFF_X), (OFF_Y));                                            \
-            float weight = (WEIGHT);                                                                            \
-            bool onscreen = IsOnScreen(sample_pos, depth_tm1_size);                                             \
-            fWeightSum += onscreen ? 0.0f : weight;                                                             \
-            if (onscreen && weight > bilinear_weight_threshold) {                                               \
-                float prev_depth = float(no_diff(g.b._DepthTm1Tex[uint4(b, 0, uint2(sample_pos))])) * INV_DEPTH_SCALE; \
-                float prev_view_depth = no_diff(GetViewSpaceDepth(prev_depth, g.pc._DeviceToViewDepth));        \
-                float depth_diff = current_view_depth - prev_view_depth;                                        \
-                if (depth_diff > 0.0f) {                                                                        \
-                    float depth_threshold = max(current_view_depth, prev_view_depth);                           \
-                    float required_sep = required_sep_scale * depth_threshold;                                  \
-                    float sep_ratio = saturate(required_sep / max(depth_diff, EPS));                            \
-                    fDepth += pow(sep_ratio, depth_clip_power) * weight;                                        \
-                    fWeightSum += weight;                                                                       \
-                }                                                                                               \
-            }                                                                                                   \
-        }
-
-    NSS_DEPTH_CLIP_SAMPLE_BLOCK(0, 0, w00);
-    NSS_DEPTH_CLIP_SAMPLE_BLOCK(1, 0, w10);
-    NSS_DEPTH_CLIP_SAMPLE_BLOCK(0, 1, w01);
-    NSS_DEPTH_CLIP_SAMPLE_BLOCK(1, 1, w11);
-
-    #undef NSS_DEPTH_CLIP_SAMPLE_BLOCK
-
-    return fWeightSum > 0.0f ? saturate(1.0f - fDepth / fWeightSum) : 0.0f;
+    return sample_tensor(g.b._DisocclusionMaskLQTex, b, 0, disocclusion_uv);
 #else
     return no_diff(
         ComputeDepthClip(
             g.b._DepthTm1Tex,
             b,
-            reproj_270p_uv,
+            disocclusion_uv,
             float2(g.pc._RenderSize),
             inverted_depth,
             depth_dilated,
@@ -533,6 +524,8 @@ inline float4 CalculateLumaDerivative(
     Globals g,
     uint b,
     int2 ref_coord,
+    float2 derivative_uv,
+    float2 derivative_inv_dims,
     float4 deriv_tm1,
     float disocclusion_mask,
     out float instability)
@@ -572,6 +565,24 @@ inline float4 CalculateLumaDerivative(
     const float instability_fall_alpha = 0.05f;     // Slow decay alpha used when a hot pixel still has meaningful carry support.
     const float spatial_support_scale = 0.75f;      // Overall gain applied after blending temporal center delta with spatial support.
     const float spatial_support_blend = 0.30f;      // Weight of current-frame spatial support vs. center temporal delta in the blended score.
+#if NSS_V1_LOW_MID_LUMA_DERIVATIVE
+    const float moire_temporal_floor = 0.10f;       // Temporal moire max where high-range recall begins.
+    const float moire_temporal_ceil = 0.30f;        // Temporal moire max where high-range recall saturates.
+    const float moire_range_floor = 0.99f;          // Current-frame moire range where high-range recall begins.
+    const float moire_range_ceil = 0.999f;          // Current-frame moire range where high-range recall saturates.
+    const float moire_range_scale = 0.50f;          // Cap for high-range temporal moire recall.
+    const float flat_temporal_floor = 0.015f;       // Coherent flat-region temporal change where recall begins.
+    const float flat_temporal_ceil = 0.030f;        // Coherent flat-region temporal change where recall saturates.
+    const float flat_range_floor = 0.040f;          // Current-frame range where flat-region recall starts being rejected.
+    const float flat_range_ceil = 0.120f;           // Current-frame range where flat-region recall is fully rejected.
+    const float flat_blue_floor = 0.220f;           // Blue bias where flat-region recall begins.
+    const float flat_blue_ceil = 0.300f;            // Blue bias where flat-region recall saturates.
+    const float flat_luma_floor = 0.450f;           // Lower Y bound for the blue flat-region recall.
+    const float flat_luma_ceil = 1.050f;            // Upper Y bound for the blue flat-region recall.
+    const float flat_rgb_b_floor = 0.800f;          // Lower derivative-domain B bound for blue flat-region recall.
+    const float flat_rgb_b_ceil = 1.400f;           // Upper derivative-domain B bound for blue flat-region recall.
+    const float flat_flicker_scale = 0.75f;         // Cap for coherent blue flat-region flicker recall.
+#endif // NSS_V1_LOW_MID_LUMA_DERIVATIVE
 
     // Load current-frame color for this pixel and its axial neighbors in the
     // derivative domain. `LoadColorForDerivativeAtPixel(...)` already applies
@@ -598,6 +609,35 @@ inline float4 CalculateLumaDerivative(
     float spatial_delta_max = max(max(d_n, d_s), max(d_e, d_w));
     float prev_instability = deriv_tm1.w;
 
+#if NSS_V1_LOW_MID_LUMA_DERIVATIVE
+    // Some moire-sized shimmer moves across local preprocess pixels without
+    // producing enough same-pixel delta to pass the normal supported-instability
+    // entry path. Sample a wider axial cross and require both temporal change
+    // and very high current-frame moire range before igniting.
+    int2 temporal_input_step = max(int2(g.pc._InvScale + 0.5f), int2(1));
+    int2 moire_input_step = temporal_input_step;
+    float2 moire_derivative_step = derivative_inv_dims;
+    float3 ycocg_tn = no_diff(RGBToYCoCg(LoadColorForDerivativeAtPixel(g, b, ref_coord + int2(0, -moire_input_step.y))));
+    float3 ycocg_ts = no_diff(RGBToYCoCg(LoadColorForDerivativeAtPixel(g, b, ref_coord + int2(0, moire_input_step.y))));
+    float3 ycocg_te = no_diff(RGBToYCoCg(LoadColorForDerivativeAtPixel(g, b, ref_coord + int2(moire_input_step.x, 0))));
+    float3 ycocg_tw = no_diff(RGBToYCoCg(LoadColorForDerivativeAtPixel(g, b, ref_coord + int2(-moire_input_step.x, 0))));
+    float4 deriv_tm1_n = LoadDerivativeTm1(g, b, derivative_uv + float2(0.0f, -moire_derivative_step.y));
+    float4 deriv_tm1_s = LoadDerivativeTm1(g, b, derivative_uv + float2(0.0f, moire_derivative_step.y));
+    float4 deriv_tm1_e = LoadDerivativeTm1(g, b, derivative_uv + float2(moire_derivative_step.x, 0.0f));
+    float4 deriv_tm1_w = LoadDerivativeTm1(g, b, derivative_uv + float2(-moire_derivative_step.x, 0.0f));
+    float d_tn = ComputeDerivativeDelta(ycocg_tn, deriv_tm1_n.xyz, chroma_weight);
+    float d_ts = ComputeDerivativeDelta(ycocg_ts, deriv_tm1_s.xyz, chroma_weight);
+    float d_te = ComputeDerivativeDelta(ycocg_te, deriv_tm1_e.xyz, chroma_weight);
+    float d_tw = ComputeDerivativeDelta(ycocg_tw, deriv_tm1_w.xyz, chroma_weight);
+    float r_tn = ComputeDerivativeDelta(ycocg_c, ycocg_tn, chroma_weight);
+    float r_ts = ComputeDerivativeDelta(ycocg_c, ycocg_ts, chroma_weight);
+    float r_te = ComputeDerivativeDelta(ycocg_c, ycocg_te, chroma_weight);
+    float r_tw = ComputeDerivativeDelta(ycocg_c, ycocg_tw, chroma_weight);
+    float temporal_moire_max = max(max(d_center, d_tn), max(max(d_ts, d_te), d_tw));
+    float current_moire_range = max(max(r_tn, r_ts), max(r_te, r_tw));
+    float flat_temporal_min = min(min(d_center, d_tn), min(min(d_ts, d_te), d_tw));
+#endif // NSS_V1_LOW_MID_LUMA_DERIVATIVE
+
     // Build a robust spatial-support estimate from the current frame only:
     // average the 3 weakest axial deltas and throw away the single strongest.
     // This keeps one bad neighbor from dominating the support score.
@@ -611,6 +651,29 @@ inline float4 CalculateLumaDerivative(
     // only one reprojected history tap.
     float spatial_support = max(spatial_delta_sum - spatial_delta_max, 0.0f) * (1.0f / 3.0f);
     float supported_instability = lerp(d_center, spatial_support, spatial_support_blend) * spatial_support_scale;
+#if NSS_V1_LOW_MID_LUMA_DERIVATIVE
+    float moire_temporal_gate = saturate(
+        (temporal_moire_max - moire_temporal_floor) * rcp(moire_temporal_ceil - moire_temporal_floor)
+    );
+    float moire_range_entry = saturate(
+        (current_moire_range - moire_range_floor) * rcp(moire_range_ceil - moire_range_floor)
+    ) * moire_temporal_gate * moire_range_scale;
+    float flat_temporal_gate = saturate(
+        (flat_temporal_min - flat_temporal_floor) * rcp(flat_temporal_ceil - flat_temporal_floor)
+    );
+    float flat_range_gate = 1.0f - saturate(
+        (current_moire_range - flat_range_floor) * rcp(flat_range_ceil - flat_range_floor)
+    );
+    float flat_blue_bias = (-0.75f * ycocg_c.y) - (0.5f * ycocg_c.z);
+    float flat_blue_gate = saturate((flat_blue_bias - flat_blue_floor) * rcp(flat_blue_ceil - flat_blue_floor));
+    float flat_luma_gate = saturate((ycocg_c.x - flat_luma_floor) * rcp(0.10f))
+        * (1.0f - saturate((ycocg_c.x - flat_luma_ceil) * rcp(0.20f)));
+    float flat_rgb_b = ycocg_c.x - (0.5f * (ycocg_c.y + ycocg_c.z));
+    float flat_rgb_b_gate = saturate((flat_rgb_b - flat_rgb_b_floor) * rcp(0.10f))
+        * (1.0f - saturate((flat_rgb_b - flat_rgb_b_ceil) * rcp(0.20f)));
+    float flat_surface_gate = flat_range_gate * flat_blue_gate * flat_luma_gate * flat_rgb_b_gate;
+    float flat_flicker_entry = flat_temporal_gate * flat_surface_gate * flat_flicker_scale;
+#endif // NSS_V1_LOW_MID_LUMA_DERIVATIVE
 
     // Entry logic for new instability.
     //
@@ -626,6 +689,9 @@ inline float4 CalculateLumaDerivative(
     float excursion_score = saturate((recall_excursion - excursion_floor) * rcp(excursion_ceil - excursion_floor));
     float mean_gate = saturate((supported_instability - mean_gate_floor) * rcp(mean_gate_ceil - mean_gate_floor));
     float raw_entry = sqrt(recall_score) * sqrt(excursion_score) * mean_gate;
+#if NSS_V1_LOW_MID_LUMA_DERIVATIVE
+    raw_entry = max(raw_entry, max(moire_range_entry, flat_flicker_entry));
+#endif // NSS_V1_LOW_MID_LUMA_DERIVATIVE
 
     // Sustain / carry logic for pixels that were already hot.
     //
@@ -678,6 +744,9 @@ inline float4 CalculateLumaDerivative(
     float output_fall_alpha = 0.80f;
     float output_alpha = filtered_instability > prev_instability ? output_rise_alpha : output_fall_alpha;
     float visible_instability = lerp(prev_instability, filtered_instability, output_alpha);
+#if NSS_V1_LOW_MID_LUMA_DERIVATIVE
+    visible_instability = max(visible_instability, max(moire_range_entry, flat_flicker_entry));
+#endif // NSS_V1_LOW_MID_LUMA_DERIVATIVE
 
     // This is the candidate next history state for the normal valid-history
     // path: current YCoCg plus the newly filtered scalar instability.
@@ -878,23 +947,61 @@ public void pre_process(PREPROCESS_PARAMS(DECL))
     int2 depth_coord = InputCoordToDepthCoord(g, ref_coord);
     float2 reproj_270p_uv = ((float2(depth_coord) + 0.5f) * inv_depth_tm1_size) - (motion * inv_low_res_size);
     float2 reproj_pad_uv = uv_pad - no_diff(MotionToPaddedUvDelta(g, motion));
+    float2 disocclusion_uv = (float2(process_coord) + 0.5f) * g.pc._InvOutputDims;
 #else
     float2 reproj_270p_uv = ((float2(ref_coord / 2) + 0.5f) * inv_depth_tm1_size) - (motion * inv_low_res_size);
     float2 reproj_pad_uv = uv_pad - (motion * inv_size);
+    float2 disocclusion_uv = reproj_270p_uv;
 #endif // NSS_PREPROCESS_HALF_RES_INPUT
 
-    float disocclusion_mask = ComputeDisocclusion(g, idx.x, reproj_270p_uv, depth_dilated, inverted_depth);
+    float disocclusion_mask = ComputeDisocclusion(g, idx.x, disocclusion_uv, depth_dilated, inverted_depth);
     float3 unjittered_color = LoadColorUnjittered(g, idx.x, unjitter_uv);
-    float3 lr_warped_history = WarpHistory(g, idx.x, reproj_uv);
-
+    float3 lr_warped_history;
 #if NSS_PREPROCESS_HALF_RES_INPUT
-    float4 deriv_tm1 = LoadDerivativeTm1(g, idx.x, reproj_pad_uv);
+    {
+        int2 history_base_input_coord = HalfResProcessCoordToBaseInputCoord(g, process_coord);
+        int2 history_lane_input_00 = history_base_input_coord;
+        int2 history_lane_input_10 = min(history_base_input_coord + int2(1, 0), g.pc._InputDims - 1);
+        int2 history_lane_input_01 = min(history_base_input_coord + int2(0, 1), g.pc._InputDims - 1);
+        int2 history_lane_input_11 = min(history_base_input_coord + int2(1, 1), g.pc._InputDims - 1);
+
+        PreProcessLaneData history_lane_00 = BuildPreProcessLaneData(g, idx.x, history_lane_input_00);
+        PreProcessLaneData history_lane_10 = BuildPreProcessLaneData(g, idx.x, history_lane_input_10);
+        PreProcessLaneData history_lane_01 = BuildPreProcessLaneData(g, idx.x, history_lane_input_01);
+        PreProcessLaneData history_lane_11 = BuildPreProcessLaneData(g, idx.x, history_lane_input_11);
+        lr_warped_history = AverageWarpedHistory2x2(
+            g,
+            idx.x,
+            history_lane_00,
+            history_lane_10,
+            history_lane_01,
+            history_lane_11
+        );
+    }
 #else
-    float4 deriv_tm1 = LoadDerivativeTm1(g, idx.x, reproj_uv);
+    lr_warped_history = WarpHistory(g, idx.x, reproj_uv);
 #endif // NSS_PREPROCESS_HALF_RES_INPUT
+
+    float2 derivative_uv = reproj_uv;
+    float2 derivative_inv_dims = inv_low_res_size;
+#if NSS_PREPROCESS_HALF_RES_INPUT
+    derivative_uv = reproj_pad_uv;
+    derivative_inv_dims = inv_size;
+#endif // NSS_PREPROCESS_HALF_RES_INPUT
+
+    float4 deriv_tm1 = LoadDerivativeTm1(g, idx.x, derivative_uv);
     float instability = 0.0f;
 #if NSS_V1_LUMA_DERIVATIVE
-    float4 luma = CalculateLumaDerivative(g, idx.x, ref_coord, deriv_tm1, disocclusion_mask, instability);
+    float4 luma = CalculateLumaDerivative(
+        g,
+        idx.x,
+        ref_coord,
+        derivative_uv,
+        derivative_inv_dims,
+        deriv_tm1,
+        disocclusion_mask,
+        instability
+    );
 #else
     float4 luma = CalculateLumaDerivative(unjittered_color, deriv_tm1, disocclusion_mask, instability);
 #endif // NSS_V1_LUMA_DERIVATIVE

--- a/tests/core/unit/utils/test_init_config_file.py
+++ b/tests/core/unit/utils/test_init_config_file.py
@@ -80,6 +80,8 @@ class TestGeneratingConfigFile(unittest.TestCase):
         self.assertEqual(config_path.name, "nss_config.json")
         self.assertEqual(config_data["model"]["version"], "1")
         self.assertEqual(config_data["model"]["quality"], "high")
+        self.assertTrue(config_data["model"]["nss_v1_luma_derivative"])
+        self.assertTrue(config_data["model"]["nss_v1_sharp_theta"])
         self.assertFalse(config_data["model"]["normalize_lr_motion"])
         self.assertTrue(config_data["model"]["gt_history_augmentation"])
         self.assertEqual(config_data["model"]["gt_history_augmentation_chance"], 30.0)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -72,6 +72,7 @@ TEST_PARAMS_PRESETS = {
                 "min_weight": 0.1,
             },
         },
+        "processing": {"shader_accurate": True},
     },
     "nfru": {
         "model": {
@@ -153,6 +154,9 @@ def create_simple_params(
     model = copy.deepcopy(usecase_preset["model"])
     dataset = copy.deepcopy(usecase_preset["dataset"])
     train_overrides = copy.deepcopy(usecase_preset.get("train", {}))
+    processing = copy.deepcopy(
+        usecase_preset.get("processing", {"shader_accurate": False})
+    )
 
     dataset["path"] = {
         "train": dataset_path,
@@ -166,7 +170,7 @@ def create_simple_params(
 
     default_params = {
         "model": model,
-        "processing": {"shader_accurate": False},
+        "processing": processing,
         "dataset": dataset,
         "output": {
             "dir": output_dir,

--- a/tests/usecases/nss/unit/data/nss_v1_golden_values/nss_v1_low_nss_output_golden.pt
+++ b/tests/usecases/nss/unit/data/nss_v1_golden_values/nss_v1_low_nss_output_golden.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ee3f2c92565a53c2c02acf8c23a84562968763b5c8fa5784218d71e26c77215
+oid sha256:97a3e04c0c57ba04e6e0683007ca74ff8edac7f32f3b7c01194270fec650d1f5
 size 16126421

--- a/tests/usecases/nss/unit/data/nss_v1_golden_values/nss_v1_mid_nss_output_golden.pt
+++ b/tests/usecases/nss/unit/data/nss_v1_golden_values/nss_v1_mid_nss_output_golden.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b632acd5cb288a6878a0320fcc0939ced8b259712fe4e31e5222db47e9e31b6f
+oid sha256:827f88b06d68a9c64f216d10de7f5192a85fa2573e7f5ebfab87e31fdcee84f8
 size 16126421

--- a/tests/usecases/nss/unit/data/nss_v1_golden_values/nss_v1_mid_preprocess_output_golden.pt
+++ b/tests/usecases/nss/unit/data/nss_v1_golden_values/nss_v1_mid_preprocess_output_golden.pt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1b0b3e114d6f8ecc007f702a30c0b78b912ae8dfbe27e2632cdb6c68733943db
-size 666765
+oid sha256:9163b5bdfc54e78e71f91662b4984ecc9565d94b2cc903e041172ff987f50638
+size 658165

--- a/tests/usecases/nss/unit/nss_v1_test_utils.py
+++ b/tests/usecases/nss/unit/nss_v1_test_utils.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import torch
+
+from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
+from tests.testing_utils import create_simple_params
+
+_GOLDEN_VALUES_DIR = Path("tests/usecases/nss/unit/data/nss_v1_golden_values")
+NSS_V1_COMMON_OUTPUT_KEYS = (
+    "output",
+    "output_linear",
+    "out_filtered",
+    "temporal_params",
+    "disocclusion_mask",
+    "derivative",
+    "ground_truth",
+    "input_color",
+)
+NSS_V1_CORE_OUTPUT_KEYS = NSS_V1_COMMON_OUTPUT_KEYS
+NSS_V1_RECURRENT_OUTPUT_KEYS = NSS_V1_COMMON_OUTPUT_KEYS + ("reset_event", "motion")
+
+
+def load_nss_v1_golden(filename: str, device: torch.device) -> dict:
+    """Load NSS v1 golden test data on the requested device."""
+
+    return torch.load(
+        _GOLDEN_VALUES_DIR / filename,
+        map_location=device,
+        weights_only=True,
+    )
+
+
+def create_nss_v1_test_params(quality: str):
+    """Create shared NSS v1 params used by unit tests."""
+
+    params = create_simple_params(usecase="nss_v1")
+    params.model_train_eval_mode = TrainEvalMode.FP32
+    params.model.quality = quality
+    params.model.recurrent_samples = 2
+    params.train.batch_size = 2
+    return params
+
+
+def tensor_values(values: dict) -> dict[str, torch.Tensor]:
+    """Return tensor entries from a loaded golden-value dictionary."""
+
+    return {
+        key: value for key, value in values.items() if isinstance(value, torch.Tensor)
+    }
+
+
+def assert_tensors_close(
+    actual: dict,
+    expected: dict,
+    keys: tuple[str, ...],
+    *,
+    rtol: float,
+    atol: float,
+) -> None:
+    """Assert that selected tensors in two dictionaries are close."""
+
+    for key in keys:
+        torch.testing.assert_close(
+            actual[key],
+            expected[key],
+            rtol=rtol,
+            atol=atol,
+        )

--- a/tests/usecases/nss/unit/test_nss_v1_model.py
+++ b/tests/usecases/nss/unit/test_nss_v1_model.py
@@ -85,6 +85,7 @@ class _NSSV1ModelTestMixin:
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.params = create_simple_params(usecase="nss_v1")
+        self.params.processing.shader_accurate = True
         self.params.model_train_eval_mode = TrainEvalMode.FP32
         self.params.train.batch_size = 2
         self.params.model.recurrent_samples = 4
@@ -145,6 +146,38 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
         self.assertEqual(settings.scale, 2.0)
         self.assertIsInstance(settings.scale, float)
 
+    def test_config_defaults_nss_v1_runtime_shader_variants_to_enabled(self) -> None:
+        """NSS v1 config enables runtime shader variant toggles by default."""
+
+        settings = NSSModelSettings(
+            name="nss",
+            model_source="prebuilt",
+            version="1",
+            scale=2.0,
+            recurrent_samples=4,
+            quality="high",
+        )
+
+        self.assertTrue(settings.nss_v1_luma_derivative)
+        self.assertTrue(settings.nss_v1_sharp_theta)
+
+    def test_config_accepts_disabled_nss_v1_runtime_shader_variants(self) -> None:
+        """NSS v1 config accepts explicit disabled runtime shader variants."""
+
+        settings = NSSModelSettings(
+            name="nss",
+            model_source="prebuilt",
+            version="1",
+            scale=2.0,
+            recurrent_samples=4,
+            quality="high",
+            nss_v1_luma_derivative=False,
+            nss_v1_sharp_theta=False,
+        )
+
+        self.assertFalse(settings.nss_v1_luma_derivative)
+        self.assertFalse(settings.nss_v1_sharp_theta)
+
     def test_config_preserves_legacy_nss_scale_contract(self) -> None:
         """Legacy NSS configs remain restricted to the existing 2x scale."""
 
@@ -165,7 +198,18 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
 
         self.assertIsInstance(model, BaseNGModel)
         self.assertIsInstance(model.get_neural_network(), AutoEncoderV1)
-        self.assertTrue(model.shader_accurate)
+        self.assertEqual(model.motion_key, "motion_lr")
+
+    def test_shader_inaccurate_processing_is_rejected_for_nss_v1(self) -> None:
+        """NSS v1 requires shader-accurate processing config."""
+
+        self.params.processing.shader_accurate = False
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "processing.shader_accurate=True",
+        ):
+            create_model(self.params, self.device)
 
     def test_normalized_lr_motion_is_rejected_for_nss_v1(self) -> None:
         """NSS v1 requires preserved low-resolution motion vectors."""
@@ -247,7 +291,27 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
     def test_low_mid_quality_non_multiple_lr_shapes_use_half_res_processing_with_padded_state(
         self,
     ) -> None:
-        """Low and mid quality process at half LR and pad recurrent temporal/derivative state."""
+        """Low/mid non-multiple LR shapes keep padded state and depth feedback."""
+
+        def process_coord_to_source_coord(
+            process_coord: int,
+            process_size: int,
+            source_size: int,
+        ) -> int:
+            return min(
+                int((process_coord + 0.5) * (source_size / process_size)),
+                source_size - 1,
+            )
+
+        def source_coord_to_depth_coord(
+            source_coord: int,
+            source_size: int,
+            depth_size: int,
+        ) -> int:
+            return min(
+                int(((source_coord + 0.5) / source_size) * depth_size),
+                depth_size - 1,
+            )
 
         for model_quality in ("low", "mid"):
             with self.subTest(model_quality=model_quality):
@@ -275,6 +339,29 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
                 self.assertEqual(hr_shape, (self.batch_size, 3, 260, 264))
                 self.assertEqual(pad_shape, (self.batch_size, 3, 72, 72))
                 self.assertEqual(depth_shape, (self.batch_size, 1, 32, 33))
+
+                spatial_axes = (
+                    ("height", input_shape[2], process_shape[2], depth_shape[2]),
+                    ("width", input_shape[3], process_shape[3], depth_shape[3]),
+                )
+                for axis_name, source_size, process_size, depth_size in spatial_axes:
+                    with self.subTest(axis=axis_name):
+                        last_source_coord = process_coord_to_source_coord(
+                            process_coord=process_size - 1,
+                            process_size=process_size,
+                            source_size=source_size,
+                        )
+                        depth_coord_for_last_source = source_coord_to_depth_coord(
+                            source_coord=last_source_coord,
+                            source_size=source_size,
+                            depth_size=depth_size,
+                        )
+
+                        self.assertEqual(last_source_coord, source_size - 1)
+                        self.assertEqual(
+                            depth_coord_for_last_source,
+                            depth_size - 1,
+                        )
                 self.assertEqual(
                     one_frame["temporal_params_tm1"].shape,
                     (self.batch_size, 4, 72, 72),
@@ -535,9 +622,13 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
         Test Slang defines which should be used at all quality levels. Assume NSS v1.
         """
 
-        expected_filter_kernel_taps = {"low": 4, "mid": 4, "high": 9}
+        expected_quality_settings = {
+            "low": {"filter_kernel_taps": 4},
+            "mid": {"filter_kernel_taps": 4},
+            "high": {"filter_kernel_taps": 9},
+        }
 
-        for model_quality, expected_taps in expected_filter_kernel_taps.items():
+        for model_quality, expected_settings in expected_quality_settings.items():
             with self.subTest(model_quality=model_quality):
                 self.params.model.quality = model_quality
                 model = create_model(self.params, self.device)
@@ -551,9 +642,33 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
                 self.assertEqual(defines["NSS_QUALITY_LOW"], 0)
                 self.assertEqual(defines["NSS_QUALITY_MID"], 1)
                 self.assertEqual(defines["NSS_QUALITY_HIGH"], 2)
-                self.assertEqual(defines["FILTER_COLOR_KERNEL_SZ"], expected_taps)
+                self.assertEqual(
+                    defines["FILTER_COLOR_KERNEL_SZ"],
+                    expected_settings["filter_kernel_taps"],
+                )
                 self.assertEqual(defines["NSS_V1_LUMA_DERIVATIVE"], 1)
                 self.assertEqual(defines["NSS_V1_SHARP_THETA"], 1)
+                self.assertIs(defines["SHADER_ACCURATE"], True)
+
+    def test_slang_defines_can_disable_v1_runtime_shader_variants(self) -> None:
+        """NSS v1 config can disable both runtime shader variants."""
+
+        self.params.model.quality = "low"
+        self.params.model.nss_v1_luma_derivative = False
+        self.params.model.nss_v1_sharp_theta = False
+
+        model = create_model(self.params, self.device)
+        with patch(
+            "ng_model_gym.usecases.nss.model.model_v1.load_slang_module",
+            return_value=object(),
+        ) as load_module:
+            model._get_slang()
+
+        defines = load_module.call_args.kwargs["defines"]
+        self.assertEqual(defines["NSS_V1_LUMA_DERIVATIVE"], 0)
+        self.assertEqual(defines["NSS_V1_LOW_MID_LUMA_DERIVATIVE"], 0)
+        self.assertEqual(defines["NSS_V1_SHARP_THETA"], 0)
+        self.assertIs(defines["SHADER_ACCURATE"], True)
 
     def test_high_quality_slang_defines(self) -> None:
         """Test Slang defines which should be used for high quality."""
@@ -573,6 +688,8 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
         self.assertEqual(defines["NSS_USE_SPARSE_2X2_FILTER"], False)
         self.assertEqual(defines["NSS_USE_HISTORY_CATMULL"], True)
         self.assertEqual(defines["NSS_PACKED_NEAREST_OFFSET_QUAD"], False)
+        self.assertEqual(defines["NSS_V1_LUMA_DERIVATIVE"], 1)
+        self.assertEqual(defines["NSS_V1_LOW_MID_LUMA_DERIVATIVE"], 0)
 
     def test_mid_quality_slang_defines(self) -> None:
         """Test Slang defines which should be used for mid quality."""
@@ -592,6 +709,8 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
         self.assertEqual(defines["NSS_USE_SPARSE_2X2_FILTER"], True)
         self.assertEqual(defines["NSS_USE_HISTORY_CATMULL"], True)
         self.assertEqual(defines["NSS_PACKED_NEAREST_OFFSET_QUAD"], True)
+        self.assertEqual(defines["NSS_V1_LUMA_DERIVATIVE"], 1)
+        self.assertEqual(defines["NSS_V1_LOW_MID_LUMA_DERIVATIVE"], 1)
 
     def test_low_quality_slang_defines(self) -> None:
         """Test Slang defines which should be used for low quality."""
@@ -605,12 +724,14 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
             model._get_slang()
 
         defines = load_module.call_args.kwargs["defines"]
-        self.assertEqual(defines["NSS_QUALITY"], 0)  # 1 = "low"
+        self.assertEqual(defines["NSS_QUALITY"], 0)  # 0 = "low"
         self.assertEqual(defines["NSS_PREPROCESS_HALF_RES_INPUT"], True)
         self.assertEqual(defines["NSS_DEPTH_SCATTER_QUARTER_RES_INPUT"], True)
         self.assertEqual(defines["NSS_USE_SPARSE_2X2_FILTER"], True)
         self.assertEqual(defines["NSS_USE_HISTORY_CATMULL"], False)
         self.assertEqual(defines["NSS_PACKED_NEAREST_OFFSET_QUAD"], True)
+        self.assertEqual(defines["NSS_V1_LUMA_DERIVATIVE"], 1)
+        self.assertEqual(defines["NSS_V1_LOW_MID_LUMA_DERIVATIVE"], 1)
 
     def test_forward_uses_available_time_dimension(self) -> None:
         """NSS v1 does not index past the input recurrent dimension."""

--- a/tests/usecases/nss/unit/test_nss_v1_model_core.py
+++ b/tests/usecases/nss/unit/test_nss_v1_model_core.py
@@ -8,9 +8,14 @@ import unittest
 import torch
 
 from ng_model_gym.core.model import create_model
-from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
 from tests.base_gpu_test import BaseGPUMemoryTest
-from tests.testing_utils import create_simple_params
+from tests.usecases.nss.unit.nss_v1_test_utils import (
+    assert_tensors_close,
+    create_nss_v1_test_params,
+    load_nss_v1_golden,
+    NSS_V1_CORE_OUTPUT_KEYS,
+    tensor_values,
+)
 
 _RTOL = 1e-2
 _ATOL = 1e-2
@@ -28,25 +33,16 @@ class TestNSSV1ModelCoreGolden(BaseGPUMemoryTest):
 
         device = torch.device("cuda")
 
-        forward_golden_inputs = torch.load(
-            "tests/usecases/nss/unit/data/nss_v1_golden_values/"
-            + "nss_v1_high_forward_pass_inputs_golden.pt",
-            map_location=device,
-            weights_only=True,
+        forward_golden_inputs = load_nss_v1_golden(
+            "nss_v1_high_forward_pass_inputs_golden.pt",
+            device,
+        )
+        forward_golden_outputs = load_nss_v1_golden(
+            "nss_v1_high_forward_pass_output_golden.pt",
+            device,
         )
 
-        forward_golden_outputs = torch.load(
-            "tests/usecases/nss/unit/data/nss_v1_golden_values/"
-            + "nss_v1_high_forward_pass_output_golden.pt",
-            map_location=device,
-            weights_only=True,
-        )
-
-        params = create_simple_params(usecase="nss_v1")
-        params.model_train_eval_mode = TrainEvalMode.FP32
-        params.model.quality = "high"
-        params.model.recurrent_samples = 2
-        params.train.batch_size = 2
+        params = create_nss_v1_test_params("high")
 
         nss_model = create_model(params, device)
         nss_model.get_neural_network().load_state_dict(
@@ -54,59 +50,14 @@ class TestNSSV1ModelCoreGolden(BaseGPUMemoryTest):
         )
         nss_model.eval()
 
-        model_inputs = {
-            key: value
-            for key, value in forward_golden_inputs.items()
-            if isinstance(value, torch.Tensor)
-        }
+        model_inputs = tensor_values(forward_golden_inputs)
         with torch.no_grad():
             model_outputs = nss_model.core_forward(model_inputs)
 
-        torch.testing.assert_close(
-            model_outputs["output"],
-            forward_golden_outputs["output"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["output_linear"],
-            forward_golden_outputs["output_linear"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["out_filtered"],
-            forward_golden_outputs["out_filtered"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["temporal_params"],
-            forward_golden_outputs["temporal_params"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["disocclusion_mask"],
-            forward_golden_outputs["disocclusion_mask"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["derivative"],
-            forward_golden_outputs["derivative"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["ground_truth"],
-            forward_golden_outputs["ground_truth"],
-            rtol=_RTOL,
-            atol=_ATOL,
-        )
-        torch.testing.assert_close(
-            model_outputs["input_color"],
-            forward_golden_outputs["input_color"],
+        assert_tensors_close(
+            model_outputs,
+            forward_golden_outputs,
+            NSS_V1_CORE_OUTPUT_KEYS,
             rtol=_RTOL,
             atol=_ATOL,
         )
@@ -122,11 +73,7 @@ class TestNSSV1ModelCoreGolden(BaseGPUMemoryTest):
 
         for quality in ("high", "mid"):
             with self.subTest(quality=quality):
-                params = create_simple_params(usecase="nss_v1")
-                params.model_train_eval_mode = TrainEvalMode.FP32
-                params.model.quality = quality
-                params.model.recurrent_samples = 2
-                params.train.batch_size = 2
+                params = create_nss_v1_test_params(quality)
 
                 nss_model = create_model(params, device)
                 nss_model.train()

--- a/tests/usecases/nss/unit/test_nss_v1_model_golden.py
+++ b/tests/usecases/nss/unit/test_nss_v1_model_golden.py
@@ -7,9 +7,14 @@ import unittest
 import torch
 
 from ng_model_gym.core.model import create_model
-from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
 from tests.base_gpu_test import BaseGPUMemoryTest
-from tests.testing_utils import create_simple_params
+from tests.usecases.nss.unit.nss_v1_test_utils import (
+    assert_tensors_close,
+    create_nss_v1_test_params,
+    load_nss_v1_golden,
+    NSS_V1_RECURRENT_OUTPUT_KEYS,
+    tensor_values,
+)
 
 _RTOL = 0.1
 _ATOL = 0.01
@@ -29,25 +34,16 @@ class TestNSSV1ModelGolden(BaseGPUMemoryTest):
             with self.subTest(quality=quality):
                 device = torch.device("cuda")
 
-                nss_golden_input = torch.load(
-                    "tests/usecases/nss/unit/data/nss_v1_golden_values/"
-                    + f"nss_v1_{quality}_nss_input_golden.pt",
-                    map_location=device,
-                    weights_only=True,
+                nss_golden_input = load_nss_v1_golden(
+                    f"nss_v1_{quality}_nss_input_golden.pt",
+                    device,
+                )
+                nss_golden_output = load_nss_v1_golden(
+                    f"nss_v1_{quality}_nss_output_golden.pt",
+                    device,
                 )
 
-                nss_golden_output = torch.load(
-                    "tests/usecases/nss/unit/data/nss_v1_golden_values/"
-                    + f"nss_v1_{quality}_nss_output_golden.pt",
-                    map_location=device,
-                    weights_only=True,
-                )
-
-                params = create_simple_params(usecase="nss_v1")
-                params.model_train_eval_mode = TrainEvalMode.FP32
-                params.model.quality = quality
-                params.model.recurrent_samples = 2
-                params.train.batch_size = 2
+                params = create_nss_v1_test_params(quality)
 
                 nss_model = create_model(params, device)
                 nss_model.get_neural_network().load_state_dict(
@@ -55,71 +51,14 @@ class TestNSSV1ModelGolden(BaseGPUMemoryTest):
                 )
                 nss_model.train()
 
-                model_input = {
-                    key: value
-                    for key, value in nss_golden_input.items()
-                    if isinstance(value, torch.Tensor)
-                }
+                model_input = tensor_values(nss_golden_input)
                 with torch.no_grad():
                     model_output = nss_model(model_input)
 
-                torch.testing.assert_close(
-                    model_output["output"],
-                    nss_golden_output["output"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["output_linear"],
-                    nss_golden_output["output_linear"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["out_filtered"],
-                    nss_golden_output["out_filtered"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["temporal_params"],
-                    nss_golden_output["temporal_params"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["disocclusion_mask"],
-                    nss_golden_output["disocclusion_mask"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["derivative"],
-                    nss_golden_output["derivative"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["ground_truth"],
-                    nss_golden_output["ground_truth"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["input_color"],
-                    nss_golden_output["input_color"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["reset_event"],
-                    nss_golden_output["reset_event"],
-                    rtol=_RTOL,
-                    atol=_ATOL,
-                )
-                torch.testing.assert_close(
-                    model_output["motion"],
-                    nss_golden_output["motion"],
+                assert_tensors_close(
+                    model_output,
+                    nss_golden_output,
+                    NSS_V1_RECURRENT_OUTPUT_KEYS,
                     rtol=_RTOL,
                     atol=_ATOL,
                 )

--- a/tests/usecases/nss/unit/test_nss_v1_post_processing.py
+++ b/tests/usecases/nss/unit/test_nss_v1_post_processing.py
@@ -276,6 +276,7 @@ class TestNSSV1PostprocessGolden(BaseGPUMemoryTest):
     @staticmethod
     def _create_model(quality, device):
         params = create_simple_params(usecase="nss_v1")
+        params.processing.shader_accurate = True
         params.model.quality = quality
         params.model.recurrent_samples = 2
         params.train.batch_size = 2

--- a/tests/usecases/nss/unit/test_nss_v1_pre_processing.py
+++ b/tests/usecases/nss/unit/test_nss_v1_pre_processing.py
@@ -9,6 +9,7 @@ import torch
 from ng_model_gym.usecases.nss.model.model_v1 import NSSV1Model
 from tests.base_gpu_test import BaseGPUMemoryTest
 from tests.testing_utils import create_simple_params
+from tests.usecases.nss.unit.nss_v1_test_utils import create_nss_v1_test_params
 
 # pylint: disable=duplicate-code
 
@@ -83,10 +84,7 @@ class TestNSSV1PreprocessSmoke(BaseGPUMemoryTest):
 
     @staticmethod
     def _create_model(quality, device):
-        params = create_simple_params(usecase="nss_v1")
-        params.model.quality = quality
-        params.model.recurrent_samples = 2
-        params.train.batch_size = 2
+        params = create_nss_v1_test_params(quality)
         model = NSSV1Model(params).to(device)
         model.eval()
         return model
@@ -334,6 +332,7 @@ class TestNSSV1PreprocessGolden(BaseGPUMemoryTest):
     @staticmethod
     def _create_model(quality, device, scale=2.0):
         params = create_simple_params(usecase="nss_v1")
+        params.processing.shader_accurate = True
         params.model.quality = quality
         params.model.scale = scale
         params.model.recurrent_samples = 2

--- a/tests/usecases/nss/unit/test_nss_v1_quality_modes.py
+++ b/tests/usecases/nss/unit/test_nss_v1_quality_modes.py
@@ -30,6 +30,7 @@ class TestNSSV1QualityModes(unittest.TestCase):
         self.assertFalse(settings.use_sparse_filter_2x2)
         self.assertTrue(settings.use_history_catmull)
         self.assertFalse(settings.packed_nearest_offset_quad)
+        self.assertFalse(settings.low_mid_luma_derivative)
         self.assertEqual(settings.kpn_size, (6, 6))
 
     def test_mid_quality_is_supported(self):
@@ -44,6 +45,7 @@ class TestNSSV1QualityModes(unittest.TestCase):
         self.assertTrue(settings.use_sparse_filter_2x2)
         self.assertTrue(settings.use_history_catmull)
         self.assertTrue(settings.packed_nearest_offset_quad)
+        self.assertTrue(settings.low_mid_luma_derivative)
         self.assertEqual(settings.kpn_size, (4, 4))
 
     def test_low_quality_is_supported(self):
@@ -58,6 +60,7 @@ class TestNSSV1QualityModes(unittest.TestCase):
         self.assertTrue(settings.use_sparse_filter_2x2)
         self.assertFalse(settings.use_history_catmull)
         self.assertTrue(settings.packed_nearest_offset_quad)
+        self.assertTrue(settings.low_mid_luma_derivative)
         self.assertEqual(settings.kpn_size, (4, 4))
 
     def test_unknown_quality_raises_value_error(self):

--- a/tests/usecases/nss/unit/test_nss_v1_shader_loading.py
+++ b/tests/usecases/nss/unit/test_nss_v1_shader_loading.py
@@ -16,15 +16,30 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
     _NSS_V1_SHADER_SOURCES = (
         _REPO_ROOT / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1.slang",
         _REPO_ROOT
+        / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1/disocclusion_lq.slang",
+        _REPO_ROOT
         / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1/pre_process.slang",
         _REPO_ROOT
         / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1/post_process.slang",
+    )
+    _NSS_V1_DEPTH_SCATTER_SOURCE = (
+        _REPO_ROOT
+        / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1/depth_scatter.slang"
+    )
+    _NSS_V1_PREPROCESS_SOURCE = (
+        _REPO_ROOT
+        / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1/pre_process.slang"
+    )
+    _NSS_V1_DISOCCLUSION_LQ_SOURCE = (
+        _REPO_ROOT
+        / "src/ng_model_gym/usecases/nss/model/shaders/nss_v1/disocclusion_lq.slang"
     )
 
     def assert_nss_v1_exports(self, module):
         """Check that the NSS v1 shader module exposes required entry points."""
 
         self.assertTrue(hasattr(module, "depth_scatter"))
+        self.assertTrue(hasattr(module, "lq_disocclusion_mask"))
         self.assertTrue(hasattr(module, "pre_process"))
         self.assertTrue(hasattr(module, "post_process"))
 
@@ -46,6 +61,7 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
             "nss_v1.slang",
             defines={
                 "NSS_V1_LUMA_DERIVATIVE": 1,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 1,
                 "NSS_V1_SHARP_THETA": 1,
                 "SHADER_ACCURATE": True,
             },
@@ -53,11 +69,33 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
 
         self.assert_nss_v1_exports(module)
 
+    def test_nss_v1_depth_scatter_quarter_res_thresholds_unscaled_motion(self):
+        """Quarter-res depth scatter thresholds motion before scale conversion."""
+
+        source = self._NSS_V1_DEPTH_SCATTER_SOURCE.read_text()
+
+        self.assertIn("motion *= float(length(result.xy) > 0.1f);", source)
+        self.assertIn("motion *= float(length(motion) > 0.1f);", source)
+
+    def test_nss_v1_lq_disocclusion_thresholds_unscaled_motion(self):
+        """The LQ disocclusion pre-pass thresholds source-pixel motion."""
+
+        self.assertTrue(self._NSS_V1_DISOCCLUSION_LQ_SOURCE.exists())
+
+        source = self._NSS_V1_DISOCCLUSION_LQ_SOURCE.read_text()
+
+        self.assertIn("LqDisocclusionMotionToDepthPixels", source)
+        self.assertIn(
+            "length(motion_pixels) > LQ_DISOCCLUSION_MOTION_THRESHOLD",
+            source,
+        )
+
     def test_nss_v1_shader_sources_use_v1_macro_names_only(self):
         """The v1 shader port uses NSS v1 macro names only."""
 
         expected_versioned_macros = {
             "NSS_V1_LUMA_DERIVATIVE",
+            "NSS_V1_LOW_MID_LUMA_DERIVATIVE",
             "NSS_V1_SHARP_THETA",
         }
         found_versioned_macros = set()
@@ -82,16 +120,19 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
         define_cases = (
             {
                 "NSS_V1_LUMA_DERIVATIVE": 0,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 0,
                 "NSS_V1_SHARP_THETA": 1,
                 "SHADER_ACCURATE": True,
             },
             {
                 "NSS_V1_LUMA_DERIVATIVE": 1,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 1,
                 "NSS_V1_SHARP_THETA": 0,
                 "SHADER_ACCURATE": True,
             },
             {
                 "NSS_V1_LUMA_DERIVATIVE": 0,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 0,
                 "NSS_V1_SHARP_THETA": 0,
                 "SHADER_ACCURATE": True,
             },
@@ -123,6 +164,7 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
                 "NSS_PACKED_NEAREST_OFFSET_QUAD": 1,
                 "FILTER_COLOR_KERNEL_SZ": 4,
                 "NSS_V1_LUMA_DERIVATIVE": 1,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 1,
                 "NSS_V1_SHARP_THETA": 1,
                 "SHADER_ACCURATE": True,
             },
@@ -138,6 +180,7 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
                 "NSS_PACKED_NEAREST_OFFSET_QUAD": 1,
                 "FILTER_COLOR_KERNEL_SZ": 4,
                 "NSS_V1_LUMA_DERIVATIVE": 1,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 1,
                 "NSS_V1_SHARP_THETA": 1,
                 "SHADER_ACCURATE": True,
             },
@@ -153,6 +196,7 @@ class TestNSSV1ShaderLoading(BaseGPUMemoryTest):
                 "NSS_PACKED_NEAREST_OFFSET_QUAD": 0,
                 "FILTER_COLOR_KERNEL_SZ": 9,
                 "NSS_V1_LUMA_DERIVATIVE": 1,
+                "NSS_V1_LOW_MID_LUMA_DERIVATIVE": 0,
                 "NSS_V1_SHARP_THETA": 1,
                 "SHADER_ACCURATE": True,
             },


### PR DESCRIPTION
- Add NSS v1 low/mid luminance-derivative shader variant define while keeping high quality unchanged.
- Add the NSS v1 LQ disocclusion pre-pass shader and wrapper export.
- Run the LQ disocclusion mask before preprocess for half-res low/mid quality modes.
- Update preprocess to consume the precomputed LQ mask for half-res modes and keep high quality using direct depth clip.
- Update half-res history reprojection to average the 2x2 warped history lanes.
- Require processing.shader_accurate=True for NSS v1 and reject normalized LR motion.
- Add config/schema/template toggles for NSS v1 luma derivative and sharp-theta runtime variants.
- Update low/mid golden outputs for the new derivative and preprocess behavior.
- Extend shader-loading and model tests for new defines, LQ disocclusion export, quality-mode defines, and config defaults.


Change-Id: Id1878c744341f08dfd4f6e8236fc200f5ff628c0