### PR TITLE
MLMOD-504: Update qparam fake quantizer for NFRU

### DIFF
--- a/src/ng_model_gym/core/model/base_ng_model.py
+++ b/src/ng_model_gym/core/model/base_ng_model.py
@@ -16,6 +16,7 @@ from torch import nn
 from torch.fx import GraphModule
 from torch.nn.modules.module import T
 from torchao.quantization.pt2e import (
+    FusedMovingAvgObsFakeQuantize,
     move_exported_model_to_eval,
     move_exported_model_to_train,
     MovingAverageMinMaxObserver,
@@ -48,6 +49,7 @@ class QATQuantizationProfile:
     use_fixed_sigmoid_output_qparams: bool = True
     activation_fake_quant_eps: float = 2e-12
     weight_fake_quant_eps: float = 2e-12
+    preserve_qat_qparams: bool = True
 
 
 class BaseNGModel(nn.Module, ABC):
@@ -205,7 +207,11 @@ class BaseNGModel(nn.Module, ABC):
         # Configure TOSA Quantizer
         quantizer = TOSAQuantizer(TosaSpecification.create_from_string(tosa_spec))
         qprofile = self.get_qat_quantization_profile()
-        fake_quant_ctor = FusedMovingAvgObsFakeQuantizeFix
+        fake_quant_ctor = (
+            FusedMovingAvgObsFakeQuantizeFix
+            if qprofile.preserve_qat_qparams
+            else FusedMovingAvgObsFakeQuantize
+        )
 
         # Activations get asymmetric per-tensor with moving average of min/max
         extra_args: Dict[str, Any] = {"eps": qprofile.activation_fake_quant_eps}

--- a/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
+++ b/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
@@ -137,6 +137,7 @@ class NFRUv1(BaseNGModel):
             use_fixed_sigmoid_output_qparams=False,
             activation_fake_quant_eps=_QAT_FAKE_QUANT_EPS,
             weight_fake_quant_eps=_QAT_FAKE_QUANT_EPS,
+            preserve_qat_qparams=False,
         )
 
     def on_after_batch_transfer(

--- a/tests/core/unit/model/test_base_ng_model_qat.py
+++ b/tests/core/unit/model/test_base_ng_model_qat.py
@@ -5,8 +5,12 @@ import unittest
 
 import torch
 from torch import nn
+from torchao.quantization.pt2e import FusedMovingAvgObsFakeQuantize
 
 from ng_model_gym.core.model import BaseNGModel
+from ng_model_gym.core.quantization.observers import FusedMovingAvgObsFakeQuantizeFix
+from ng_model_gym.usecases.nfru.model.nfru_v1 import NFRUv1
+from ng_model_gym.usecases.nss.model.model_v1 import NSSV1Model
 from tests.testing_utils import create_simple_params
 
 # pylint: disable=missing-function-docstring
@@ -67,6 +71,24 @@ class TestBaseNGModelQAT(unittest.TestCase):
         self.assertTrue(isinstance(model.get_neural_network(), torch.fx.GraphModule))
         out = model(self.mock_forward_input)
         self.assertEqual(out.shape, (4, 4))
+
+    def test_qparam_policy_selects_fake_quantizer(self):
+        """Test NSS uses the fake quantizer fix whilst NFRU uses standard torchAO fake quantizer"""
+        for model_type, usecase, channels, expected_fake_quantizer_type in (
+            (NSSV1Model, "nss_v1", 12, FusedMovingAvgObsFakeQuantizeFix),
+            (NFRUv1, "nfru", 16, FusedMovingAvgObsFakeQuantize),
+        ):
+            with self.subTest(usecase=usecase):
+                model = model_type(create_simple_params(usecase=usecase))
+                model.quantize_modules((torch.randn(2, channels, 16, 16),))
+                self.assertEqual(
+                    {
+                        type(module)
+                        for module in model.get_neural_network().modules()
+                        if isinstance(module, FusedMovingAvgObsFakeQuantize)
+                    },
+                    {expected_fake_quantizer_type},
+                )
 
     def test_double_quantize_raises(self):
         """Test if attempting to quantize modules twice raises"""


### PR DESCRIPTION
* NFRU now uses TorchAO fake quantizer instead of patched version used by NSS

Signed-off-by: Ayaan Masood <ayaan.masood@arm.com>
Change-Id: I9552cef060eec9df10bf4e99c1d8bff3267a0f95
