### PR TITLE
Improve QAT fake quantization

### DIFF
--- a/src/ng_model_gym/core/model/base_ng_model.py
+++ b/src/ng_model_gym/core/model/base_ng_model.py
@@ -33,6 +33,7 @@ from ng_model_gym.core.quantization.observers import (
     enable_all_observers,
     freeze_all_observers,
     FusedMovingAvgObsFakeQuantizeFix,
+    replace_fixed_qparams_fake_quant,
 )
 from ng_model_gym.core.utils.enum_definitions import ExportSpec
 from ng_model_gym.core.utils.torch_utils import TensorData
@@ -318,7 +319,9 @@ class BaseNGModel(nn.Module, ABC):
                 check_guards=False
             )
             # Insert FakeQuantizer nodes
-            return prepare_qat_pt2e(aten_dialect, quantizer)
+            qat_module = prepare_qat_pt2e(aten_dialect, quantizer)
+            replace_fixed_qparams_fake_quant(qat_module)
+            return qat_module
 
         # Grab the relevant layer to quantize
         quantized_network = trace_and_quantize_module(current_network, input_data)

--- a/src/ng_model_gym/core/quantization/__init__.py
+++ b/src/ng_model_gym/core/quantization/__init__.py
@@ -4,6 +4,8 @@
 
 from .observers import (
     enable_all_observers,
+    FixedQParamsFakeQuantizeFix,
     freeze_all_observers,
     FusedMovingAvgObsFakeQuantizeFix,
+    replace_fixed_qparams_fake_quant,
 )

--- a/src/ng_model_gym/core/quantization/observers.py
+++ b/src/ng_model_gym/core/quantization/observers.py
@@ -2,12 +2,197 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import types
 
 import torch
-from torchao.quantization.pt2e import FusedMovingAvgObsFakeQuantize
+from torchao.quantization.pt2e import (
+    FixedQParamsFakeQuantize,
+    FusedMovingAvgObsFakeQuantize,
+)
 from torchao.quantization.pt2e.fake_quantize import FakeQuantizeBase
 from torchao.quantization.pt2e.observer import ObserverBase
+
+logger = logging.getLogger(__name__)
+
+
+def _sanitize_fake_quant_qparams(m: FakeQuantizeBase) -> None:
+    """Keep fake-quant buffers within the range accepted by Torch kernels."""
+    observer = getattr(m, "activation_post_process", None)
+    if observer is None or not hasattr(m, "scale") or not hasattr(m, "zero_point"):
+        return
+
+    with torch.no_grad():
+        m.scale.nan_to_num_(nan=1.0, posinf=1.0, neginf=1.0)
+        m.scale.clamp_(min=float(getattr(m, "eps", 2e-12)))
+
+        quant_min = getattr(observer, "quant_min", None)
+        quant_max = getattr(observer, "quant_max", None)
+        if quant_min is None or quant_max is None:
+            return
+
+        if torch.is_floating_point(m.zero_point):
+            m.zero_point.nan_to_num_(
+                nan=0.0,
+                posinf=float(quant_max),
+                neginf=float(quant_min),
+            )
+        m.zero_point.clamp_(quant_min, quant_max)
+
+
+def _set_fake_quant_observer_enabled(m: FakeQuantizeBase, enabled: bool) -> None:
+    """Set an observer flag without replacing a registered tensor buffer."""
+    observer_enabled = getattr(m, "observer_enabled", None)
+    if isinstance(observer_enabled, torch.Tensor):
+        observer_enabled.fill_(1 if enabled else 0)
+    elif observer_enabled is not None:
+        setattr(m, "observer_enabled", enabled)
+
+
+def _is_zero_point_range_error(error: RuntimeError) -> bool:
+    return "`zero_point` must be between `quant_min` and `quant_max`" in str(error)
+
+
+def _should_sanitize_after_fused_fake_quant() -> bool:
+    return not torch.compiler.is_compiling()
+
+
+def _disable_fake_quant_observer_after_qparam_error(
+    m: FakeQuantizeBase, reason: str
+) -> None:
+    _sanitize_fake_quant_qparams(m)
+    _set_fake_quant_observer_enabled(m, False)
+    m._disable_observer_after_zero_point_error = True
+    if not getattr(m, "_logged_zero_point_observer_disable", False):
+        logger.warning(
+            "Disabling observer updates for %s after %s.",
+            m.__class__.__name__,
+            reason,
+        )
+        m._logged_zero_point_observer_disable = True
+
+
+def _fake_quant_flag_enabled(m: FakeQuantizeBase, flag: str) -> bool:
+    """Read a fake-quant flag on eager-only paths."""
+    value = getattr(m, flag, None)
+    if isinstance(value, torch.Tensor):
+        return bool(value[0].item())
+    return bool(value)
+
+
+def _update_qparams_from_observer(m: FakeQuantizeBase, x: torch.Tensor) -> None:
+    """Update registered qparam buffers, recovering from invalid observations."""
+    old_min = getattr(m.activation_post_process, "min_val", None)
+    old_max = getattr(m.activation_post_process, "max_val", None)
+    old_min = old_min.clone() if isinstance(old_min, torch.Tensor) else None
+    old_max = old_max.clone() if isinstance(old_max, torch.Tensor) else None
+
+    try:
+        m.activation_post_process(x.detach())
+        scale, zero_point = m.activation_post_process.calculate_qparams()
+    except (AssertionError, RuntimeError) as error:
+        if old_min is not None and hasattr(m.activation_post_process, "min_val"):
+            m.activation_post_process.min_val.copy_(old_min)
+        if old_max is not None and hasattr(m.activation_post_process, "max_val"):
+            m.activation_post_process.max_val.copy_(old_max)
+        _disable_fake_quant_observer_after_qparam_error(
+            m,
+            f"observer qparam calculation failed: {error}",
+        )
+        return
+
+    scale = scale.to(m.scale.device)
+    zero_point = zero_point.to(m.zero_point.device)
+    if m.scale.shape != scale.shape:
+        m.scale.resize_(scale.shape)
+        m.zero_point.resize_(zero_point.shape)
+    m.scale.copy_(scale)
+    m.zero_point.copy_(zero_point)
+
+
+def _apply_fake_quant(m: FakeQuantizeBase, x: torch.Tensor) -> torch.Tensor:
+    if not _fake_quant_flag_enabled(m, "fake_quant_enabled"):
+        return x
+
+    if getattr(m, "is_per_channel", False):
+        return torch.fake_quantize_per_channel_affine(
+            x,
+            m.scale,
+            m.zero_point,
+            m.ch_axis,
+            m.activation_post_process.quant_min,
+            m.activation_post_process.quant_max,
+        )
+
+    return torch.fake_quantize_per_tensor_affine(
+        x,
+        m.scale,
+        m.zero_point,
+        m.activation_post_process.quant_min,
+        m.activation_post_process.quant_max,
+    )
+
+
+def _forward_unfused_with_sanitized_qparams(
+    m: FakeQuantizeBase, x: torch.Tensor
+) -> torch.Tensor:
+    """Run eager fake quant with qparam sanitation and one recovery retry."""
+    if getattr(m, "_disable_observer_after_zero_point_error", False):
+        _set_fake_quant_observer_enabled(m, False)
+
+    _sanitize_fake_quant_qparams(m)
+    if _fake_quant_flag_enabled(m, "observer_enabled"):
+        _update_qparams_from_observer(m, x)
+        _sanitize_fake_quant_qparams(m)
+
+    try:
+        return _apply_fake_quant(m, x)
+    except RuntimeError as error:
+        if not _is_zero_point_range_error(error):
+            raise
+        _disable_fake_quant_observer_after_qparam_error(
+            m,
+            "torch fake-quant produced an out-of-range zero_point",
+        )
+        return _apply_fake_quant(m, x)
+    finally:
+        _sanitize_fake_quant_qparams(m)
+
+
+def _forward_fused_with_sanitized_qparams(
+    m: FusedMovingAvgObsFakeQuantize, x: torch.Tensor
+) -> torch.Tensor:
+    if getattr(m, "_disable_observer_after_zero_point_error", False):
+        _set_fake_quant_observer_enabled(m, False)
+
+    try:
+        output = torch.fused_moving_avg_obs_fake_quant(
+            x,
+            m.observer_enabled,
+            m.fake_quant_enabled,
+            m.activation_post_process.min_val,
+            m.activation_post_process.max_val,
+            m.scale,
+            m.zero_point,
+            m.activation_post_process.averaging_constant,
+            m.activation_post_process.quant_min,
+            m.activation_post_process.quant_max,
+            m.ch_axis,
+            m.is_per_channel,
+            m.is_symmetric_quant,
+        )
+    except RuntimeError as error:
+        if not _is_zero_point_range_error(error):
+            raise
+        _disable_fake_quant_observer_after_qparam_error(
+            m,
+            "torch fused fake-quant produced an out-of-range zero_point",
+        )
+        return _forward_unfused_with_sanitized_qparams(m, x)
+
+    if _should_sanitize_after_fused_fake_quant():
+        _sanitize_fake_quant_qparams(m)
+    return output
 
 
 class FusedMovingAvgObsFakeQuantizeFix(FusedMovingAvgObsFakeQuantize):
@@ -43,6 +228,61 @@ class FusedMovingAvgObsFakeQuantizeFix(FusedMovingAvgObsFakeQuantize):
     def calculate_qparams(self) -> tuple[torch.Tensor, torch.Tensor]:
         """Getter for scale and zero points."""
         return self.scale, self.zero_point
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        """Apply fake quantization using sanitized quantization parameters."""
+        return _forward_fused_with_sanitized_qparams(self, X)
+
+
+class FixedQParamsFakeQuantizeFix(FixedQParamsFakeQuantize):
+    """Compile-friendly, sanitized fixed-qparams fake quantization."""
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        """Apply fake quantization using sanitized quantization parameters."""
+        if not torch.compiler.is_compiling():
+            return _forward_unfused_with_sanitized_qparams(self, X)
+
+        observer = self.activation_post_process
+        if getattr(self, "is_per_channel", False):
+            quantized = torch.fake_quantize_per_channel_affine(
+                X,
+                self.scale,
+                self.zero_point,
+                self.ch_axis,
+                observer.quant_min,
+                observer.quant_max,
+            )
+        else:
+            quantized = torch.fake_quantize_per_tensor_affine(
+                X,
+                self.scale,
+                self.zero_point,
+                observer.quant_min,
+                observer.quant_max,
+            )
+        enabled = self.fake_quant_enabled.to(dtype=torch.bool)
+        return torch.where(enabled, quantized, X)
+
+
+def replace_fixed_qparams_fake_quant(module: torch.nn.Module) -> int:
+    """Recursively replace stock fixed-qparams fake-quant modules."""
+    replaced = 0
+    for name, child in list(module.named_children()):
+        if isinstance(child, FixedQParamsFakeQuantizeFix):
+            continue
+        if isinstance(child, FixedQParamsFakeQuantize):
+            observer_ctr = getattr(child, "_observer_ctr", None)
+            if observer_ctr is None:
+                continue
+            replacement = FixedQParamsFakeQuantizeFix(observer=observer_ctr)
+            replacement.load_state_dict(child.state_dict(), strict=True)
+            replacement.to(device=child.scale.device)
+            replacement.train(child.training)
+            setattr(module, name, replacement)
+            replaced += 1
+            continue
+        replaced += replace_fixed_qparams_fake_quant(child)
+    return replaced
 
 
 def _freeze_one(m: torch.nn.Module):

--- a/tests/core/unit/model/test_base_ng_model_qat.py
+++ b/tests/core/unit/model/test_base_ng_model_qat.py
@@ -6,9 +6,13 @@ import unittest
 import torch
 from torch import nn
 from torchao.quantization.pt2e import FusedMovingAvgObsFakeQuantize
+from torchao.quantization.pt2e.fake_quantize import FixedQParamsFakeQuantize
 
 from ng_model_gym.core.model import BaseNGModel
-from ng_model_gym.core.quantization.observers import FusedMovingAvgObsFakeQuantizeFix
+from ng_model_gym.core.quantization.observers import (
+    FixedQParamsFakeQuantizeFix,
+    FusedMovingAvgObsFakeQuantizeFix,
+)
 from ng_model_gym.usecases.nfru.model.nfru_v1 import NFRUv1
 from ng_model_gym.usecases.nss.model.model_v1 import NSSV1Model
 from tests.testing_utils import create_simple_params
@@ -89,6 +93,27 @@ class TestBaseNGModelQAT(unittest.TestCase):
                     },
                     {expected_fake_quantizer_type},
                 )
+                fixed_qparams = [
+                    module
+                    for module in model.get_neural_network().modules()
+                    if isinstance(module, FixedQParamsFakeQuantize)
+                ]
+                if usecase == "nss_v1":
+                    self.assertTrue(
+                        any(
+                            isinstance(module, FixedQParamsFakeQuantizeFix)
+                            for module in fixed_qparams
+                        )
+                    )
+                    self.assertFalse(
+                        any(
+                            isinstance(module, FixedQParamsFakeQuantize)
+                            and not isinstance(module, FixedQParamsFakeQuantizeFix)
+                            for module in fixed_qparams
+                        )
+                    )
+                else:
+                    self.assertEqual(fixed_qparams, [])
 
     def test_double_quantize_raises(self):
         """Test if attempting to quantize modules twice raises"""

--- a/tests/core/unit/quantization/test_observers.py
+++ b/tests/core/unit/quantization/test_observers.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: <text>Copyright 2026 Arm Limited and/or
+# its affiliates <open-source-office@arm.com></text>
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest import mock
+
+import torch
+from torchao.quantization.pt2e import MovingAverageMinMaxObserver
+from torchao.quantization.pt2e.fake_quantize import FixedQParamsFakeQuantize
+from torchao.quantization.pt2e.observer import FixedQParamsObserver
+
+from ng_model_gym.core.quantization import (
+    FixedQParamsFakeQuantizeFix,
+    FusedMovingAvgObsFakeQuantizeFix,
+    replace_fixed_qparams_fake_quant,
+)
+
+# pylint: disable=missing-function-docstring
+
+_ZERO_POINT_ERROR = "`zero_point` must be between `quant_min` and `quant_max`"
+
+
+def _fused_fake_quant():
+    return FusedMovingAvgObsFakeQuantizeFix(
+        observer=MovingAverageMinMaxObserver.with_args(
+            dtype=torch.int8,
+            quant_min=-128,
+            quant_max=127,
+        ),
+        quant_min=-128,
+        quant_max=127,
+    )
+
+
+def _fixed_fake_quant(fake_quant_type=FixedQParamsFakeQuantizeFix):
+    return fake_quant_type(
+        observer=FixedQParamsObserver.with_args(
+            scale=1.0 / 254.0,
+            zero_point=-127,
+            dtype=torch.int8,
+            qscheme=torch.per_tensor_affine,
+            quant_min=-127,
+            quant_max=127,
+        )
+    )
+
+
+class TestFakeQuantObservers(unittest.TestCase):
+    """Test hardened fake-quant behavior."""
+
+    def assert_qparams_are_safe(self, fake_quant):
+        observer = fake_quant.activation_post_process
+        self.assertTrue(torch.all(torch.isfinite(fake_quant.scale)))
+        self.assertTrue(torch.all(fake_quant.scale > 0))
+        self.assertGreaterEqual(int(fake_quant.zero_point.min()), observer.quant_min)
+        self.assertLessEqual(int(fake_quant.zero_point.max()), observer.quant_max)
+
+    def test_fused_fake_quant_sanitizes_invalid_qparams(self):
+        fake_quant = _fused_fake_quant()
+        x = torch.ones(4)
+
+        def fused_kernel(*_args):
+            fake_quant.scale.fill_(float("nan"))
+            fake_quant.zero_point.fill_(torch.iinfo(fake_quant.zero_point.dtype).min)
+            return x
+
+        with mock.patch(
+            "torch.fused_moving_avg_obs_fake_quant", side_effect=fused_kernel
+        ):
+            fake_quant(x)
+
+        self.assert_qparams_are_safe(fake_quant)
+
+    def test_fused_fake_quant_recovers_from_zero_point_error(self):
+        fake_quant = _fused_fake_quant()
+        fake_quant.zero_point.fill_(torch.iinfo(fake_quant.zero_point.dtype).min)
+        x = torch.ones(4)
+
+        with (
+            mock.patch(
+                "torch.fused_moving_avg_obs_fake_quant",
+                side_effect=RuntimeError(_ZERO_POINT_ERROR),
+            ),
+            self.assertLogs(
+                "ng_model_gym.core.quantization.observers", level="WARNING"
+            ),
+        ):
+            output = fake_quant(x)
+
+        torch.testing.assert_close(output, x)
+        self.assertEqual(fake_quant.observer_enabled.item(), 0)
+        self.assert_qparams_are_safe(fake_quant)
+
+    def test_fused_fake_quant_does_not_hide_unrelated_errors(self):
+        fake_quant = _fused_fake_quant()
+
+        with mock.patch(
+            "torch.fused_moving_avg_obs_fake_quant",
+            side_effect=RuntimeError("unrelated failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "unrelated failure"):
+                fake_quant(torch.ones(4))
+
+    def test_fixed_fake_quant_compiles_and_respects_enabled_flag(self):
+        fake_quant = _fixed_fake_quant()
+        compiled = torch.compile(fake_quant, backend="eager", fullgraph=True)
+        x = torch.linspace(0.0, 1.0, 16)
+
+        torch.testing.assert_close(compiled(x), fake_quant(x))
+
+        fake_quant.disable_fake_quant()
+        torch.testing.assert_close(compiled(x), x)
+
+    def test_replacement_preserves_state(self):
+        module = torch.nn.Sequential(
+            torch.nn.Sequential(_fixed_fake_quant(FixedQParamsFakeQuantize))
+        )
+        original_state = {
+            name: value.clone() for name, value in module.state_dict().items()
+        }
+
+        self.assertEqual(replace_fixed_qparams_fake_quant(module), 1)
+
+        replacement = module[0][0]
+        self.assertIs(type(replacement), FixedQParamsFakeQuantizeFix)
+        for name, value in original_state.items():
+            torch.testing.assert_close(module.state_dict()[name], value)
+        self.assertEqual(replace_fixed_qparams_fake_quant(module), 0)


### PR DESCRIPTION
* Sanitise invalid scale and zero point values during QAT
* Add compile friendly fixed qparam fake quantization
* Replace fixed-qparam modules during QAT preparation

Signed-off-by: Ayaan Masood <ayaan.masood@arm.com>
Change-Id: Iab22efbe7b3866d8e214c536bd52e68df9810e40
