### PR TITLE
Rename model configs to NSS-v1 and NFRU-v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ Most commands use a configuration file and require the following steps:
    ng-model-gym init <model-template> [save_dir]
    ```
 
-   Example: NSS and NFRU configuration files are created from the `nss` and `nfru` templates. The following commands will create NSS and NFRU configuration files in the current directory:
+   Example: NSS v1 and NFRU v1 configuration files are created from the `nss-v1` and `nfru-v1` templates. The following commands will create NSS and NFRU configuration files in the current directory:
 
    ```bash
-   ng-model-gym init nss
-   ng-model-gym init nfru
+   ng-model-gym init nss-v1
+   ng-model-gym init nfru-v1
    ```
 
 3. **Edit your model configuration file:** Configuration files contain paths to local datasets and options for the different usage modes (training, evaluation, and exporting). Some entries initially contain placeholder values (e.g. `<...>`); make sure to replace those with your own settings.
@@ -151,7 +151,7 @@ import ng_model_gym as ngmg
 
 # Generate a config file in an existing directory using the API or CLI
 # Note: The config file must be filled in before use.
-ngmg.generate_config_file("nss", "/save/dir")
+ngmg.generate_config_file("nss-v1", "/save/dir")
 ```
 
 ```python

--- a/docs/adding-custom-models-and-datasets.md
+++ b/docs/adding-custom-models-and-datasets.md
@@ -17,7 +17,7 @@ There are two common ways to add models and datasets:
 If you copy a prebuilt model (such as NSS), modify the class decorator to register it under a new name (for example, `MyNSSModel`). Use the prebuilt model config, set `model.name/model.version` to your new registration, and keep `model_source: "prebuilt"`.
 
 ```bash
-ng-model-gym init nss [save_dir]
+ng-model-gym init nss-v1 [save_dir]
 ```
 
 ```json
@@ -74,7 +74,7 @@ Depending on how you interact with ng-model-gym (CLI or API), model and dataset 
 
 ##### Using the CLI
 
-Models/datasets registered under the `ng_model_gym/usecases` folder are auto-discovered. Outside of this folder, the CLI does not search for registered models/datasets. 
+Models/datasets registered under the `ng_model_gym/usecases` folder are auto-discovered. Outside of this folder, the CLI does not search for registered models/datasets.
 
 A suggested layout is:
 

--- a/docs/nfru/nfru_configuration.md
+++ b/docs/nfru/nfru_configuration.md
@@ -11,7 +11,7 @@ Before reading further, please read `docs/usage.md`. That file explains how to c
 
 Model Gym's NFRU model requires a configuration file, typically named `nfru_config.json`. This file is initially generated using the following command:
 
-    ng-model-gym init nfru
+    ng-model-gym init nfru-v1
 
 This document is a guide to the most common changes you will need to make to `nfru_config.json`. For more details, refer to `schema_config.json`, which contains a detailed description of every configuration setting.
 

--- a/docs/nss/nss_configuration.md
+++ b/docs/nss/nss_configuration.md
@@ -11,7 +11,7 @@ Before reading further, please read `docs/usage.md`. That file explains how to c
 
 Model Gym's NSS model requires a configuration file, typically named `nss_config.json`. This file is initially generated using the following command:
 
-    ng-model-gym init nss
+    ng-model-gym init nss-v1
 
 This document is a guide to the most common changes you will need to make to `nss_config.json`. For more details, refer to `schema_config.json`, which contains a detailed description of every configuration setting.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,7 +27,7 @@ ng-model-gym init --list
 # Or simply: ng-model-gym init
 ```
 
-Standard templates include `nss` and `nfru`; these relate to Model Gym's NSS and NFRU models.
+Standard templates include `nss-v1` and `nfru-v1`; these relate to Model Gym's NSS v1 and NFRU v1 models.
 
 To generate a configuration file from a template, use a command of this form:
 ```bash
@@ -35,9 +35,9 @@ ng-model-gym init <configuration-template> [save_dir]
 
 # e.g.
 # - Generate an NSS configuration file in the current directory:
-ng-model-gym init nss
+ng-model-gym init nss-v1
 # - Generate an NFRU configuration file in an existing directory:
-ng-model-gym init nfru config-dir
+ng-model-gym init nfru-v1 config-dir
 ```
 
 This command creates two files in the selected output directory (or your working directory if `save_dir` is omitted):
@@ -229,7 +229,7 @@ import ng_model_gym as ngmg
 
 # Generate a config file in an existing directory using the API or CLI
 # Note: The config file must be filled in before use.
-ngmg.generate_config_file("nss", "/save/dir")
+ngmg.generate_config_file("nss-v1", "/save/dir")
 ```
 
 ```python

--- a/src/ng_model_gym/core/config/config_model.py
+++ b/src/ng_model_gym/core/config/config_model.py
@@ -27,7 +27,7 @@ from ng_model_gym.core.utils.enum_definitions import (
 
 # pylint: disable=line-too-long
 
-CONFIG_SCHEMA_VERSION = "8"
+CONFIG_SCHEMA_VERSION = "9"
 
 # Pydantic models representing the configuration file structure.
 # For fields which are not core to all model types (e.g. recurrent_samples),
@@ -172,10 +172,10 @@ class CustomModelSettings(BaseModelSettings):
     model_config = ConfigDict(extra="allow", revalidate_instances="always")
 
 
-class NSSModelSettings(PrebuiltModelSettingsBase):
+class NSSV1ModelSettings(PrebuiltModelSettingsBase):
     """NSS model settings"""
 
-    name: Literal["nss"]
+    name: Literal["nss-v1"]
     scale: StrictFloat = Field(
         2.0,
         gt=1.0,
@@ -222,10 +222,10 @@ class NSSModelSettings(PrebuiltModelSettingsBase):
     )
 
 
-class NFRUModelSettings(PrebuiltModelSettingsBase):
+class NFRUV1ModelSettings(PrebuiltModelSettingsBase):
     """NFRU model settings"""
 
-    name: Literal["nfru"]
+    name: Literal["nfru-v1"]
     scale_factor: StrictFloat = Field(
         default=2.0,
         ge=2.0,
@@ -274,7 +274,7 @@ class NFRUModelSettings(PrebuiltModelSettingsBase):
 
 # DO NOT FORGET TO ADD NEW MODEL SETTINGS HERE
 prebuilt_models_settings = Annotated[
-    Union[NSSModelSettings, NFRUModelSettings],
+    Union[NSSV1ModelSettings, NFRUV1ModelSettings],
     Field(discriminator="name"),
 ]
 
@@ -578,7 +578,7 @@ class ConfigModel(PydanticConfigModel):
     @model_validator(mode="after")
     def _validate_nfru_color_preprocessing(self):
         """Require explicit color-preprocessing config for NFRU v1."""
-        if getattr(self.model, "name", None) != "nfru":
+        if getattr(self.model, "name", None) != "nfru-v1":
             return self
 
         color_preprocessing = self.dataset.color_preprocessing

--- a/src/ng_model_gym/core/config/config_utils.py
+++ b/src/ng_model_gym/core/config/config_utils.py
@@ -133,7 +133,7 @@ def generate_config_file(
         Tuple[Path, Path]: Paths to the generated configuration JSON and schema JSON files.
 
     Example:
-        >>> config_output_path, schema_path = generate_config_file("nss", Path("./output"))
+        >>> config_output_path, schema_path = generate_config_file("nss-v1", Path("./output"))
     """
 
     if save_dir:

--- a/src/ng_model_gym/core/config/custom_template.json
+++ b/src/ng_model_gym/core/config/custom_template.json
@@ -1,5 +1,5 @@
 {
-    "config_schema_version": "8",
+    "config_schema_version": "9",
     "model": {
         "name": "<NAME_OF_REGISTERED_MODEL>",
         "model_source": "custom",

--- a/src/ng_model_gym/core/config/schema_config.json
+++ b/src/ng_model_gym/core/config/schema_config.json
@@ -1,6 +1,6 @@
 {
     "config_schema_version": {
-        "default": "8",
+        "default": "9",
         "description": "Config schema version. Used to check compatibility.",
         "type": "string"
     },
@@ -16,7 +16,7 @@
                 "oneOf": [
                     {
                         "name": {
-                            "const": "nss",
+                            "const": "nss-v1",
                             "type": "string"
                         },
                         "version": {
@@ -88,7 +88,7 @@
                     },
                     {
                         "name": {
-                            "const": "nfru",
+                            "const": "nfru-v1",
                             "type": "string"
                         },
                         "version": {

--- a/src/ng_model_gym/core/export/model_export.py
+++ b/src/ng_model_gym/core/export/model_export.py
@@ -367,7 +367,9 @@ def executorch_vgf_export(
     model_forward_input = tree_map(to_cpu, model_forward_input)
     model_forward_input = tree_map(to_channels_last, model_forward_input)
 
-    model_key = get_model_key(params.model.name, params.model.version)
+    model_version = getattr(model, "version", None)
+
+    model_key = get_model_key(params.model.name, model_version)
 
     metadata_path = (
         Path(params.output.export.vgf_output_dir)

--- a/src/ng_model_gym/core/model/model_factory.py
+++ b/src/ng_model_gym/core/model/model_factory.py
@@ -16,10 +16,10 @@ logger = logging.getLogger(__name__)
 
 def get_model_from_config(params: ConfigModel) -> Type[BaseNGModel]:
     """Return the registered model class from the model registry,
-    using the name and version supplied in the config file."""
+    using the name (and optionally version) supplied in the config file."""
 
     model_name = params.model.name
-    model_version = params.model.version
+    model_version = params.model.version if params.model.version else None
 
     model_key = get_model_key(model_name, model_version)
 

--- a/src/ng_model_gym/core/model/model_registry.py
+++ b/src/ng_model_gym/core/model/model_registry.py
@@ -59,7 +59,7 @@ def register_model(name: str, version: Optional[str] = None):
 
     Example::
 
-        @register_model(name="NSS", version="0.1")
+        @register_model(name="NSS-v1")
         class NSS_Model(BaseNGModel)
             pass
     """

--- a/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
+++ b/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
@@ -1,9 +1,8 @@
 {
-    "config_schema_version": "8",
+    "config_schema_version": "9",
     "model": {
-        "name": "NFRU",
+        "name": "NFRU-v1",
         "model_source": "prebuilt",
-        "version": "1",
         "scale_factor": 2.0,
         "legacy_nfru_capture_paths": [],
         "dynamic_mask_is_runtime_accurate": false,

--- a/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
+++ b/src/ng_model_gym/usecases/nfru/model/nfru_v1.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch
 from torch import nn
 
-from ng_model_gym.core.config.config_model import ConfigModel, NFRUModelSettings
+from ng_model_gym.core.config.config_model import ConfigModel, NFRUV1ModelSettings
 from ng_model_gym.core.model.base_ng_model import BaseNGModel, QATQuantizationProfile
 from ng_model_gym.core.model.graphics_utils import normalize_mvs
 from ng_model_gym.core.model.model_registry import register_model
@@ -88,15 +88,15 @@ def _get_color_config(params: ConfigModel) -> dict[str, dict]:
     return {split: dict(color_preprocessing[split]) for split in _REQUIRED_COLOR_SPLITS}
 
 
-@register_model(name="NFRU", version="1")
+@register_model(name="NFRU-v1")
 class NFRUv1(BaseNGModel):
     """NFRU v1 exposed through the BaseNGModel interface."""
 
     def __init__(self, params: ConfigModel):
         super().__init__(params)
-        if not isinstance(self.params.model, NFRUModelSettings):
+        if not isinstance(self.params.model, NFRUV1ModelSettings):
             raise TypeError(
-                "model section in parameter is not of type NFRUModelSettings"
+                "model section in parameter is not of type NFRUV1ModelSettings"
             )
         self.params = params
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/src/ng_model_gym/usecases/nss/configs/nss_v1_template.json
+++ b/src/ng_model_gym/usecases/nss/configs/nss_v1_template.json
@@ -1,9 +1,8 @@
 {
-    "config_schema_version": "8",
+    "config_schema_version": "9",
     "model": {
-        "name": "NSS",
+        "name": "NSS-v1",
         "model_source": "prebuilt",
-        "version": "1",
         "scale": 2.0,
         "recurrent_samples": 16,
         "quality": "high",

--- a/src/ng_model_gym/usecases/nss/model/model_v1.py
+++ b/src/ng_model_gym/usecases/nss/model/model_v1.py
@@ -11,7 +11,7 @@ from typing import Dict, Optional
 import torch
 from torch import nn
 
-from ng_model_gym.core.config.config_model import ConfigModel, NSSModelSettings
+from ng_model_gym.core.config.config_model import ConfigModel, NSSV1ModelSettings
 from ng_model_gym.core.data.data_utils import HDR_MAX, tonemap_forward
 from ng_model_gym.core.model.base_ng_model import BaseNGModel
 from ng_model_gym.core.model.graphics_utils import (
@@ -43,7 +43,7 @@ _NSS_V1_SHADER_QUALITY_DEFINES = {
 }
 
 
-@register_model(name="NSS", version="1")
+@register_model(name="NSS-v1")
 class NSSV1Model(BaseNGModel):
     """NSS v1 model for training and evaluation flows."""
 
@@ -51,7 +51,7 @@ class NSSV1Model(BaseNGModel):
         """Set up the NSS v1 model."""
         super().__init__(params)
 
-        if not isinstance(self.params.model, NSSModelSettings):
+        if not isinstance(self.params.model, NSSV1ModelSettings):
             raise TypeError(
                 "model section in parameter is not of type NSSModelSettings"
             )

--- a/tests/core/export/test_executorch_integration.py
+++ b/tests/core/export/test_executorch_integration.py
@@ -95,7 +95,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
         for model in models:
             with self.subTest(model):
                 # Load config and setup for current test
-                params = create_simple_params(usecase="nss_v1")
+                params = create_simple_params(usecase="nss-v1")
                 params.dataset.path.validation = Path("tests/usecases/nss/datasets/val")
                 params.output.export.vgf_output_dir = self.tosa_out_dir
                 params.model_train_eval_mode = TrainEvalMode.FP32
@@ -122,7 +122,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
 
         for model in models:
             # Load config and setup for current test
-            params = create_simple_params(usecase="nss_v1")
+            params = create_simple_params(usecase="nss-v1")
             params.output.export.vgf_output_dir = self.tosa_out_dir
             params.dataset.path.validation = Path("tests/usecases/nss/datasets/val")
 
@@ -166,7 +166,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
         ]
 
         for model in models:
-            params = create_simple_params(usecase="nss_v1")
+            params = create_simple_params(usecase="nss-v1")
             params.output.export.vgf_output_dir = self.tosa_out_dir
             params.dataset.path.train = Path("tests/usecases/nss/datasets/train")
 
@@ -203,7 +203,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
 
     def test_export_function_raises_error_missing_dataset_path(self):
         """Test export raises error if missing dataset path"""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.output.export.vgf_output_dir = self.tosa_out_dir
 
         # Ensure tosa output directory does not exist
@@ -237,7 +237,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
 
     def test_export_raises_no_dynamic_or_static_config(self):
         """Test export raises error if dynamic is set to false and there is no static export cfg"""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.output.export.dynamic_shape = False
         params.output.export.vgf_static_input_shape = None
         params.output.export.vgf_output_dir = self.tosa_out_dir
@@ -258,7 +258,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
     def test_static_export(self):
         """Test export passes if dynamic is set to false and there is a static export cfg"""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.output.export.dynamic_shape = False
         params.output.export.vgf_static_input_shape = [[1, 12, 256, 256]]
         params.output.export.vgf_output_dir = self.tosa_out_dir
@@ -284,7 +284,7 @@ class TestExecuTorchIntegration(unittest.TestCase):
     def test_static_export_provided_and_dynamic_enabled(self):
         """Test warning if dynamic is set to true and there is a static export cfg"""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.output.export.dynamic_shape = True
         params.output.export.vgf_static_input_shape = [[1, 12, 256, 256]]
         params.output.export.vgf_output_dir = self.tosa_out_dir

--- a/tests/core/integration/test_CLI.py
+++ b/tests/core/integration/test_CLI.py
@@ -27,7 +27,7 @@ class CLIIntegrationTest(BaseGPUMemoryTest):
 
         # Create a valid config to use
         self.config = create_simple_params(
-            usecase="nss_v1",
+            usecase="nss-v1",
             output_dir=self.test_dir / "output",
             dataset_path="tests/usecases/nss/mini_datasets/train",
             checkpoints=self.test_dir / "checkpoints",
@@ -136,8 +136,8 @@ class CLIIntegrationTest(BaseGPUMemoryTest):
         """Testing creating config files from CLI"""
         cases = [
             ("custom", "custom_config"),
-            ("nss", "nss_config"),
-            ("nfru", "nfru_config"),
+            ("nss-v1", "nss-v1_config"),
+            ("nfru-v1", "nfru-v1_config"),
         ]
 
         env = os.environ.copy()

--- a/tests/core/integration/test_api.py
+++ b/tests/core/integration/test_api.py
@@ -22,7 +22,7 @@ class ApiCoreIntegrationTest(BaseGPUMemoryTest):
 
         # Create a valid config to use
         self.config = create_simple_params(
-            usecase="nss_v1",
+            usecase="nss-v1",
             output_dir=self.tmp_dir / "output",
             dataset_path="",
             checkpoints=self.tmp_dir / "checkpoints",

--- a/tests/core/unit/data/test_dataset_factory.py
+++ b/tests/core/unit/data/test_dataset_factory.py
@@ -33,7 +33,7 @@ class TestDatasetFactory(unittest.TestCase):
     def setUp(self):
         train_data_dir = Path("./tests/usecases/nss/datasets/train")
 
-        self.params = create_simple_params(usecase="nss_v1")
+        self.params = create_simple_params(usecase="nss-v1")
         self.params.dataset.path.train = train_data_dir
 
     def tearDown(self):

--- a/tests/core/unit/evaluator/test_evaluators.py
+++ b/tests/core/unit/evaluator/test_evaluators.py
@@ -32,7 +32,7 @@ class TestNGModelEvaluator(unittest.TestCase):
         output_dir.mkdir()
 
         # Create config model using our own data
-        self.params = create_simple_params(usecase="nss_v1", output_dir=str(output_dir))
+        self.params = create_simple_params(usecase="nss-v1", output_dir=str(output_dir))
         self.params.dataset.path.train = train_data_dir
         self.params.dataset.path.validation = val_data_dir
         self.params.dataset.path.test = test_data_dir

--- a/tests/core/unit/evaluator/test_metrics.py
+++ b/tests/core/unit/evaluator/test_metrics.py
@@ -181,7 +181,7 @@ class TestMetrics(unittest.TestCase):
 
     def test_get_metrics(self):
         """Test that get_metrics returns all our expected metrics."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
 
         metrics = get_metrics(params, mode="train")
         self.assertEqual(len(metrics), 4)

--- a/tests/core/unit/model/test_base_ng_model_qat.py
+++ b/tests/core/unit/model/test_base_ng_model_qat.py
@@ -57,7 +57,7 @@ class TestBaseNGModelQAT(unittest.TestCase):
         self.device = torch.device("cpu")
         self.mock_forward_input = torch.randn((4, 4), device=self.device)
         self.mock_forward_input_trace = (self.mock_forward_input,)
-        self.params = create_simple_params(usecase="nss_v1")
+        self.params = create_simple_params(usecase="nss-v1")
 
     def test_qat_train_raises_if_not_quantized(self):
         """Test model raises error if not prepared with fake quant observers before QAT training"""
@@ -79,8 +79,8 @@ class TestBaseNGModelQAT(unittest.TestCase):
     def test_qparam_policy_selects_fake_quantizer(self):
         """Test NSS uses the fake quantizer fix whilst NFRU uses standard torchAO fake quantizer"""
         for model_type, usecase, channels, expected_fake_quantizer_type in (
-            (NSSV1Model, "nss_v1", 12, FusedMovingAvgObsFakeQuantizeFix),
-            (NFRUv1, "nfru", 16, FusedMovingAvgObsFakeQuantize),
+            (NSSV1Model, "nss-v1", 12, FusedMovingAvgObsFakeQuantizeFix),
+            (NFRUv1, "nfru-v1", 16, FusedMovingAvgObsFakeQuantize),
         ):
             with self.subTest(usecase=usecase):
                 model = model_type(create_simple_params(usecase=usecase))
@@ -98,7 +98,7 @@ class TestBaseNGModelQAT(unittest.TestCase):
                     for module in model.get_neural_network().modules()
                     if isinstance(module, FixedQParamsFakeQuantize)
                 ]
-                if usecase == "nss_v1":
+                if usecase == "nss-v1":
                     self.assertTrue(
                         any(
                             isinstance(module, FixedQParamsFakeQuantizeFix)

--- a/tests/core/unit/model/test_model_factory.py
+++ b/tests/core/unit/model/test_model_factory.py
@@ -51,7 +51,7 @@ class TestModelFactory(unittest.TestCase):
     """Test Model Factory."""
 
     def setUp(self):
-        self.params = create_simple_params(usecase="nss_v1")
+        self.params = create_simple_params(usecase="nss-v1")
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     def tearDown(self):
@@ -60,7 +60,7 @@ class TestModelFactory(unittest.TestCase):
     def test_get_model_from_config(self):
         """Test getting the model class, based on the config file parameters."""
 
-        for model_name in ("NSS", "nss", "Nss"):
+        for model_name in ("NSS-v1", "nss-v1", "Nss-v1"):
             with self.subTest(model_name=model_name):
                 self.params.model.name = model_name
 
@@ -72,7 +72,7 @@ class TestModelFactory(unittest.TestCase):
     def test_get_nss_v1_model_from_config(self):
         """Test getting NSS v1 from the model registry."""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
 
         model_cls = get_model_from_config(params)
 
@@ -104,9 +104,8 @@ class TestModelFactory(unittest.TestCase):
 
         # pylint: enable=duplicate-code
 
-        # Override model name and version from params
+        # Override model name from params
         self.params.model.name = "MockNSSNoVersion"
-        self.params.model.version = None
 
         model_cls = get_model_from_config(self.params)
 
@@ -118,7 +117,7 @@ class TestModelFactory(unittest.TestCase):
         # Override model name from params
         self.params.model.name = "unregistered_model"
 
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
+        model_key = get_model_key(self.params.model.name)
 
         with self.assertRaisesRegex(
             KeyError,
@@ -186,9 +185,8 @@ class TestModelFactory(unittest.TestCase):
 
         # pylint: enable=duplicate-code
 
-        # Override model name and version from params
+        # Override model name from params
         self.params.model.name = "MockNSSNoParamsArg"
-        self.params.model.version = None
 
         with self.assertRaisesRegex(
             TypeError,

--- a/tests/core/unit/model/test_model_registry.py
+++ b/tests/core/unit/model/test_model_registry.py
@@ -71,16 +71,15 @@ class TestModelRegistry(unittest.TestCase):
         """Test model key returned matches expected format."""
 
         self.assertEqual(get_model_key(name="nss"), "nss")
-        self.assertEqual(get_model_key(name="nss", version="1"), "nss-v1")
-        self.assertEqual(get_model_key(name="NSS", version="1"), "nss-v1")
+        self.assertEqual(get_model_key(name="nss-v1"), "nss-v1")
+        self.assertEqual(get_model_key(name="NSS-v1"), "nss-v1")
 
     def test_model_registry_helper_func(self):
         """Test adding a valid model using the register_model() helper function."""
 
-        model_name = "NSS"
-        model_version = "1"
+        model_name = "NSS-v1"
 
-        @register_model(model_name, model_version)
+        @register_model(model_name)
         class NSSModel(MockBaseNGModel):  # pylint: disable=unused-variable
             """NSS model"""
 
@@ -99,18 +98,17 @@ class TestModelRegistry(unittest.TestCase):
 
         self.assertEqual(
             model_registry.MODEL_REGISTRY.list_registered(),
-            [get_model_key(model_name, model_version)],
+            [get_model_key(model_name)],
         )
 
     def test_model_inheritance(self):
         """Test model not inheriting from correct base class causes TypeError."""
 
-        model_name = "NSS"
-        model_version = "2"
+        model_name = "NSS-v2"
 
         with self.assertRaisesRegex(TypeError, "must inherit from BaseNGModel"):
 
-            @register_model(name=model_name, version=model_version)
+            @register_model(name=model_name)
             class NSSModel:  # pylint: disable=unused-variable
                 """NSS model"""
 
@@ -119,21 +117,20 @@ class TestModelRegistry(unittest.TestCase):
 
         self.assertNotEqual(
             model_registry.MODEL_REGISTRY.list_registered(),
-            [get_model_key(model_name, model_version)],
+            [get_model_key(model_name)],
         )
 
     def test_model_get_neural_network_not_implemented(self):
         """Test not implementing get_neural_network() causes TypeError."""
 
-        model_name = "NSS"
-        model_version = "3"
+        model_name = "NSS-v3"
 
         with self.assertRaisesRegex(
             TypeError,
             r"Make sure all abstract methods, e.g. get_neural_network\(self\), are implemented",
         ):
 
-            @register_model(model_name, model_version)
+            @register_model(model_name)
             class NSSModel(MockBaseNGModel):  # pylint: disable=unused-variable
                 """NSS model"""
 
@@ -149,18 +146,17 @@ class TestModelRegistry(unittest.TestCase):
 
         self.assertNotEqual(
             model_registry.MODEL_REGISTRY.list_registered(),
-            [get_model_key(model_name, model_version)],
+            [get_model_key(model_name)],
         )
 
     def test_model_forward_not_implemented(self):
         """Test not overriding forward() causes TypeError."""
 
-        model_name = "NSS"
-        model_version = "4"
+        model_name = "NSS-v4"
 
         with self.assertRaisesRegex(TypeError, r"must override forward\(\)"):
 
-            @register_model(model_name, model_version)
+            @register_model(model_name)
             class NSSModel(MockBaseNGModel):  # pylint: disable=unused-variable
                 """NSS model"""
 
@@ -176,38 +172,36 @@ class TestModelRegistry(unittest.TestCase):
 
         self.assertNotEqual(
             model_registry.MODEL_REGISTRY.list_registered(),
-            [get_model_key(model_name, model_version)],
+            [get_model_key(model_name)],
         )
 
     def test_model_not_a_class(self):
         """Test registering an object that isn't a class raises a TypeError."""
 
-        model_name = "NSS"
-        model_version = "5"
+        model_name = "NSS-v5"
 
         with self.assertRaisesRegex(TypeError, "must be a class"):
 
-            @register_model(model_name, model_version)
+            @register_model(model_name)
             def NSSModel():
                 pass
 
         self.assertNotEqual(
             model_registry.MODEL_REGISTRY.list_registered(),
-            [get_model_key(model_name, model_version)],
+            [get_model_key(model_name)],
         )
 
     def test_model_set_neural_network_not_implemented(self):
         """Test not implementing set_neural_network() causes TypeError."""
 
-        model_name = "NSS"
-        model_version = "6"
+        model_name = "NSS-v6"
 
         with self.assertRaisesRegex(
             TypeError,
             r"Make sure all abstract methods, e.g. get_neural_network\(self\), are implemented",
         ):
 
-            @register_model(model_name, model_version)
+            @register_model(model_name)
             class NSSModel(MockBaseNGModel):  # pylint: disable=unused-variable
                 """NSS model"""
 
@@ -223,5 +217,5 @@ class TestModelRegistry(unittest.TestCase):
 
         self.assertNotEqual(
             model_registry.MODEL_REGISTRY.list_registered(),
-            [get_model_key(model_name, model_version)],
+            [get_model_key(model_name)],
         )

--- a/tests/core/unit/model/test_model_tracer.py
+++ b/tests/core/unit/model/test_model_tracer.py
@@ -55,7 +55,7 @@ class TestModelTracer(unittest.TestCase):
     """Test model tracer"""
 
     def setUp(self):
-        self.params = create_simple_params(usecase="nss_v1")
+        self.params = create_simple_params(usecase="nss-v1")
 
     def test_tracer_captures_input_tensor(self):
         """Test tracer captures single input tensor"""

--- a/tests/core/unit/schedulers/test_lr_schedules.py
+++ b/tests/core/unit/schedulers/test_lr_schedules.py
@@ -19,7 +19,7 @@ class TestLRScheduleFunctions(unittest.TestCase):
     def setUp(self):
         """Setup test case"""
         torch.manual_seed(0)
-        self.params = create_simple_params(usecase="nss_v1")
+        self.params = create_simple_params(usecase="nss-v1")
         self.params.model_train_eval_mode = TrainEvalMode.FP32
 
     def test_cosine_annealing_schedule(self):
@@ -171,7 +171,7 @@ class TestSchedulerConfig(unittest.TestCase):
     # pylint: disable=C0116
     def setUp(self):
         """Run before each test case"""
-        self.params = create_simple_params(usecase="nss_v1").model_dump()
+        self.params = create_simple_params(usecase="nss-v1").model_dump()
 
     def test_cosine_annealing_valid(self):
         params = self.params

--- a/tests/core/unit/trainer/test_trainer.py
+++ b/tests/core/unit/trainer/test_trainer.py
@@ -307,7 +307,7 @@ class TestTrainerMethods(unittest.TestCase):
             mock_resume_trainer.lr_schedule.load_state_dict = Mock()
             mock_resume_trainer.lr_schedule.step = Mock()
 
-            mock_resume_trainer.params = create_simple_params(usecase="nss_v1")
+            mock_resume_trainer.params = create_simple_params(usecase="nss-v1")
             mock_resume_trainer.params.train.resume = Path(
                 model_save_path, "ckpt-10.pt"
             )
@@ -406,7 +406,7 @@ class TestLossFnFactory(unittest.TestCase):
     # pylint: disable=C0116
     def test_get_loss_fn_with_valid_loss_v1(self):
         """Test get_loss_fn() returns LossV1 when requested"""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.loss_fn = LossFn.LOSS_V1.value
         params.train.loss_args = {
             "temporal_reg_weight": 0.1,
@@ -425,7 +425,7 @@ class TestLossFnFactory(unittest.TestCase):
 
     def test_get_loss_fn_with_loss_v1_default_loss_args(self):
         """Test get_loss_fn() preserves the NSS v1 preset loss_args defaults."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.loss_fn = LossFn.LOSS_V1.value
         device = torch.device("cpu")
 
@@ -437,7 +437,7 @@ class TestLossFnFactory(unittest.TestCase):
 
     def test_get_loss_fn_with_loss_v1_none_loss_args_defaults_to_empty_dict(self):
         """Test get_loss_fn() defaults LossV1 loss_args to an empty dict when unset."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.loss_fn = LossFn.LOSS_V1.value
         params.train.loss_args = None
         device = torch.device("cpu")
@@ -449,7 +449,7 @@ class TestLossFnFactory(unittest.TestCase):
         self.assertEqual(loss_obj.loss_args, {})
 
     def test_get_loss_fn_raises_exception(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.loss_fn = "does_not_exist"
         with self.assertRaises(ValueError):
             _ = get_loss_fn(params, torch.device("cpu"))
@@ -462,7 +462,7 @@ class TestOptimizerFactory(unittest.TestCase):
 
     # pylint: disable=C0116
     def test_get_optimizer_type_with_valid_lars_adam_fp32(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
 
         mock_trainer = Mock(spec=Trainer)
@@ -478,7 +478,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertEqual(optimizer_obj.optim.__class__, optim.Adam)
 
     def test_get_optimizer_type_with_valid_lars_adam_qat(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.qat.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
 
         mock_trainer = Mock(spec=Trainer)
@@ -494,7 +494,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertEqual(optimizer_obj.optim.__class__, optim.Adam)
 
     def test_get_optimizer_type_with_valid_adam_w_fp32(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = OptimizerType.ADAM_W.value
 
         mock_trainer = Mock(spec=Trainer)
@@ -509,7 +509,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertIsInstance(optimizer_obj, optim.AdamW)
 
     def test_get_optimizer_type_with_valid_adam_w_qat(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.qat.optimizer.optimizer_type = OptimizerType.ADAM_W.value
 
         mock_trainer = Mock(spec=Trainer)
@@ -524,7 +524,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertIsInstance(optimizer_obj, optim.AdamW)
 
     def test_get_optimizer_type_with_custom_eps_for_adam_w(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = OptimizerType.ADAM_W.value
         params.train.fp32.optimizer.eps = 1e-5
 
@@ -541,7 +541,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertAlmostEqual(optimizer_obj.defaults["eps"], 1e-5)
 
     def test_get_optimizer_type_with_valid_adam_uses_default_eps(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = OptimizerType.ADAM.value
 
         mock_trainer = Mock(spec=Trainer)
@@ -557,7 +557,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertAlmostEqual(optimizer_obj.defaults["eps"], 1e-7)
 
     def test_get_optimizer_type_with_custom_eps(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = OptimizerType.ADAM.value
         params.train.fp32.optimizer.eps = 1e-5
 
@@ -574,7 +574,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertAlmostEqual(optimizer_obj.defaults["eps"], 1e-5)
 
     def test_get_optimizer_type_with_custom_eps_for_lars_adam(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = OptimizerType.LARS_ADAM.value
         params.train.fp32.optimizer.eps = 1e-5
 
@@ -593,7 +593,7 @@ class TestOptimizerFactory(unittest.TestCase):
         self.assertAlmostEqual(optimizer_obj.eps, 1e-8)
 
     def test_get_optimizer_type_raises_exception(self):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.fp32.optimizer.optimizer_type = "does_not_exist"
 
         mock_trainer = Mock(spec=Trainer)

--- a/tests/core/unit/utils/test_export_utils.py
+++ b/tests/core/unit/utils/test_export_utils.py
@@ -106,7 +106,7 @@ def make_params(tmp_path):
         ),
     )
 
-    p.model = SimpleNamespace(name="NSS", version="42")
+    p.model = SimpleNamespace(name="NSS-v42")
 
     p.output = SimpleNamespace(
         export=SimpleNamespace(
@@ -169,7 +169,7 @@ class TestExportUtils(unittest.TestCase):
         # Train/eval mode set correctly.
         self.assertEqual(self.params.model_train_eval_mode, TrainEvalMode.QAT_INT8)
 
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
+        model_key = get_model_key(self.params.model.name)
 
         # Metadata file should be updated with constants.
         expected_meta = Path(self.params.output.export.vgf_output_dir) / (
@@ -191,7 +191,7 @@ class TestExportUtils(unittest.TestCase):
         self.assertIsInstance(trace_input, torch.Tensor)
         self.assertEqual(etype, ExportType.QAT_INT8)
 
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
+        model_key = get_model_key(self.params.model.name)
 
         # Metadata path should match the expected path.
         expected_meta = Path(self.params.output.export.vgf_output_dir) / (
@@ -221,7 +221,7 @@ class TestExportUtils(unittest.TestCase):
         # Train/eval mode set correctly.
         self.assertEqual(self.params.model_train_eval_mode, TrainEvalMode.FP32)
 
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
+        model_key = get_model_key(self.params.model.name)
 
         # Metadata file should be updated with constants.
         expected_meta = Path(self.params.output.export.vgf_output_dir) / (
@@ -242,7 +242,7 @@ class TestExportUtils(unittest.TestCase):
         self.assertIsInstance(trace_input, torch.Tensor)
         self.assertEqual(etype, ExportType.FP32)
 
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
+        model_key = get_model_key(self.params.model.name)
 
         # Metadata path should match the expected path.
         expected_meta = Path(self.params.output.export.vgf_output_dir) / (
@@ -265,7 +265,7 @@ class TestExportUtils(unittest.TestCase):
         # Run with FP32 branch.
         executorch_vgf_export(self.params, ExportType.FP32, Path("doesnt_matter.pt"))
 
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
+        model_key = get_model_key(self.params.model.name)
 
         # Build expected path.
         meta_path = (
@@ -386,7 +386,7 @@ class TestExportUtils(unittest.TestCase):
     def test_export_module_to_vgf_rejects_odd_shapes_and_accepts_even_shapes(self):
         """Dynamic NFRU export requires even heights and widths."""
         params = make_params(self.tmp_path)
-        params.model = SimpleNamespace(name="NFRU", version="1")
+        params.model = SimpleNamespace(name="NFRU-v1")
         model = MockNFRUDynamicModel(params)
 
         accepted_input = (torch.rand(1, 16, 4, 6),)

--- a/tests/core/unit/utils/test_init_config_file.py
+++ b/tests/core/unit/utils/test_init_config_file.py
@@ -33,7 +33,7 @@ class TestGeneratingConfigFile(unittest.TestCase):
 
     def test_config_files_created(self):
         """Test the files created exist"""
-        for template in ["NSS", "NFRU"]:
+        for template in ["NSS-v1", "NFRU-v1"]:
             with self.subTest(template=template):
                 config_path, schema_path = generate_config_file(
                     template, self.output_path
@@ -58,9 +58,9 @@ class TestGeneratingConfigFile(unittest.TestCase):
 
     def test_incrementing_config_name_if_already_exists(self):
         """Test if existing configs exists, it increments the file name"""
-        config_path, _ = generate_config_file("nss", self.output_path)
-        config_path1, _ = generate_config_file("nss", self.output_path)
-        config_path2, _ = generate_config_file("nss", self.output_path)
+        config_path, _ = generate_config_file("nss-v1", self.output_path)
+        config_path1, _ = generate_config_file("nss-v1", self.output_path)
+        config_path2, _ = generate_config_file("nss-v1", self.output_path)
 
         config_template_name = config_path.stem
         self.assertEqual(config_path1.stem, f"{config_template_name}_1")
@@ -68,19 +68,20 @@ class TestGeneratingConfigFile(unittest.TestCase):
 
     def test_case_insensitive_generate_config(self):
         """Test case/whitespace insensitive generate_config template name"""
-        config_path, _ = generate_config_file("  nSs  ", self.output_path)
+        config_path, _ = generate_config_file("  nSs-v1  ", self.output_path)
 
-        self.assertEqual(config_path.name, "nss_config.json")
+        self.assertEqual(config_path.name, "nss-v1_config.json")
 
     def test_generate_nss_config_file_uses_v1_template(self):
         """Test generating the default NSS config uses the v1 template."""
-        config_path, _ = generate_config_file("NSS", self.output_path)
+        config_path, _ = generate_config_file("NSS-v1", self.output_path)
 
         with open(config_path, "r", encoding="utf-8") as f:
             config_data = json.load(f)
 
-        self.assertEqual(config_path.name, "nss_config.json")
-        self.assertEqual(config_data["model"]["version"], "1")
+        self.assertEqual(config_path.name, "nss-v1_config.json")
+        self.assertEqual(config_data["model"]["name"], "NSS-v1")
+        self.assertNotIn("version", config_data["model"])
         self.assertEqual(config_data["model"]["quality"], "high")
         self.assertTrue(config_data["model"]["nss_v1_luma_derivative"])
         self.assertTrue(config_data["model"]["nss_v1_sharp_theta"])
@@ -99,32 +100,26 @@ class TestGeneratingConfigFile(unittest.TestCase):
 
     def test_generate_nss_config_file_is_v1_by_default(self):
         """Test generating NSS keeps the v1 template as the default."""
-        config_path, _ = generate_config_file("NSS", self.output_path)
+        config_path, _ = generate_config_file("NSS-v1", self.output_path)
 
         with open(config_path, "r", encoding="utf-8") as f:
             config_data = json.load(f)
 
-        self.assertEqual(config_path.name, "nss_config.json")
-        self.assertEqual(config_data["model"]["version"], "1")
+        self.assertEqual(config_path.name, "nss-v1_config.json")
+        self.assertEqual(config_data["model"]["name"], "NSS-v1")
+        self.assertNotIn("version", config_data["model"])
 
     def test_nss_in_template_list(self):
         """Test list config templates includes nss"""
         templates = list_config_templates()
 
-        self.assertIn("NSS", templates)
-
-    def test_nss_v1_template_uses_default_name_in_template_list(self):
-        """Test list config templates exposes the v1 template through the NSS alias."""
-        templates = list_config_templates()
-
-        self.assertIn("NSS", templates)
-        self.assertNotIn("NSS_v1", templates)
+        self.assertIn("NSS-v1", templates)
 
     def test_nfru_in_template_list(self):
         """Test list config templates includes nfru"""
         templates = list_config_templates()
 
-        self.assertIn("NFRU", templates)
+        self.assertIn("NFRU-v1", templates)
 
     def test_custom_in_template_list(self):
         """Test list config templates includes custom"""
@@ -152,21 +147,21 @@ class TestGeneratingConfigFile(unittest.TestCase):
     def test_colliding_template_names(self, mock_discover):
         """Test multiple templates with the same name raises"""
         mock_discover.return_value = {
-            "nss": [
-                TemplateInfo(model_name="nss", json_data={}, source=Path("a.json")),
-                TemplateInfo(model_name="nss", json_data={}, source=Path("b.json")),
+            "nss-v1": [
+                TemplateInfo(model_name="nss-v1", json_data={}, source=Path("a.json")),
+                TemplateInfo(model_name="nss-v1", json_data={}, source=Path("b.json")),
             ]
         }
 
         with self.assertRaises(ValueError) as raised:
-            generate_config_file("nss", self.output_path)
+            generate_config_file("nss-v1", self.output_path)
 
         self.assertIn("Multiple config templates found", str(raised.exception))
 
     def test_invalid_save_dir_raises(self):
         """Test the function raises if invalid dir is passed"""
         with self.assertRaises(FileNotFoundError):
-            generate_config_file("nss", "/invalid_dir")
+            generate_config_file("nss-v1", "/invalid_dir")
 
     def test_all_templates_match_config_schema_version(self):
         """Test all discovered config templates have the current schema version."""

--- a/tests/scripts/test_config.py
+++ b/tests/scripts/test_config.py
@@ -46,7 +46,7 @@ class TestConfig(unittest.TestCase):
     def test_loading_user_config_file(self):
         """Test loading config"""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.train.seed = 9876
         params = params.model_dump_json()
 
@@ -94,7 +94,7 @@ class TestConfig(unittest.TestCase):
     def test_outdated_config_validation(self):
         """Test exception raised when parameter in user config is outdated"""
 
-        user_config = create_simple_params(usecase="nss_v1").model_dump_json()
+        user_config = create_simple_params(usecase="nss-v1").model_dump_json()
         user_config_dict = json.loads(user_config)
         user_config_dict |= {"extra": "field"}
         user_config = json.dumps(user_config_dict)
@@ -118,7 +118,7 @@ class TestConfig(unittest.TestCase):
 
     def test_invalid_json_file(self):
         """Test invalid JSON file throws exception"""
-        user_config = create_simple_params(usecase="nss_v1")
+        user_config = create_simple_params(usecase="nss-v1")
         user_config = user_config.model_dump_json()
         with tempfile.TemporaryDirectory() as tmp_dir:
             with tempfile.NamedTemporaryFile(
@@ -142,7 +142,7 @@ class TestConfig(unittest.TestCase):
     def test_reject_incomplete_config(self):
         """Test incomplete config throws exception"""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         # Delete seed param
         params = params.model_dump_json(exclude={"train": {"seed"}})
 
@@ -166,7 +166,7 @@ class TestConfig(unittest.TestCase):
     def test_reject_validation_enabled_without_valid_schedule(self):
         """Test config fails when validation is enabled but never scheduled to run."""
 
-        user_config = create_simple_params(usecase="nss_v1").model_dump(mode="json")
+        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
         user_config["train"]["perform_validate"] = True
         user_config["train"]["validate_frequency"] = 5
         user_config["train"]["fp32"]["number_of_epochs"] = 1
@@ -182,7 +182,7 @@ class TestConfig(unittest.TestCase):
     def test_accept_validation_schedule_with_int_frequency(self):
         """Test config accepts a valid validation schedule when frequency is an int."""
 
-        user_config = create_simple_params(usecase="nss_v1").model_dump(mode="json")
+        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
         user_config["train"]["perform_validate"] = True
         user_config["train"]["validate_frequency"] = 2
         user_config["train"]["fp32"]["number_of_epochs"] = 5
@@ -194,7 +194,7 @@ class TestConfig(unittest.TestCase):
     def test_accept_validation_schedule_with_list_frequency(self):
         """Test config accepts a valid validation schedule when frequency is a list."""
 
-        user_config = create_simple_params(usecase="nss_v1").model_dump(mode="json")
+        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
         user_config["train"]["perform_validate"] = True
         user_config["train"]["validate_frequency"] = [2, 5]
         user_config["train"]["fp32"]["number_of_epochs"] = 5
@@ -206,7 +206,7 @@ class TestConfig(unittest.TestCase):
     def test_custom_models(self):
         """Test custom model config accepts custom fields"""
 
-        user_config = create_simple_params(usecase="nss_v1").model_dump(mode="json")
+        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
         user_config["model"] = {
             "name": "my_model",
             "model_source": "custom",
@@ -283,7 +283,7 @@ class TestConfigLogging(unittest.TestCase):
             with open(log_file_path, "r", encoding="utf-8") as f:
                 existing_log = f.read()
 
-        user_config = create_simple_params(usecase="nss_v1")
+        user_config = create_simple_params(usecase="nss-v1")
         user_config.train.fp32.number_of_epochs = 0
         user_config.output.tensorboard_output_dir = "./tensorboard-logs"
         create_directory(user_config.output.tensorboard_output_dir)

--- a/tests/scripts/test_safetensors_writer.py
+++ b/tests/scripts/test_safetensors_writer.py
@@ -418,7 +418,7 @@ class TestNSSSafetensorsWriter(unittest.TestCase):
             output_root = self._writer_output_root(args)
 
             params = create_simple_params(
-                usecase="nss_v1", dataset_path=str(output_root)
+                usecase="nss-v1", dataset_path=str(output_root)
             )
             params.dataset.path.test = output_root
             dataset = NSSDataset(params, DataLoaderMode.TEST)

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -12,11 +12,10 @@ from ng_model_gym.core.config.config_model import ConfigModel
 from ng_model_gym.core.utils.io.file_utils import create_directory
 
 TEST_PARAMS_PRESETS = {
-    "nss_v1": {
+    "nss-v1": {
         "model": {
-            "name": "NSS",
+            "name": "NSS-v1",
             "model_source": "prebuilt",
-            "version": "1",
             "scale": 2.0,
             "recurrent_samples": 16,
             "quality": "high",
@@ -56,11 +55,10 @@ TEST_PARAMS_PRESETS = {
         },
         "metrics": ["PSNR", "tPSNR", "RecPSNR", "SSIM"],
     },
-    "nfru": {
+    "nfru-v1": {
         "model": {
-            "name": "NFRU",
+            "name": "NFRU-v1",
             "model_source": "prebuilt",
-            "version": "1",
             "scale_factor": 2.0,
             "legacy_nfru_capture_paths": [],
             "dynamic_mask_is_runtime_accurate": False,
@@ -148,7 +146,7 @@ def create_simple_params(
     """
     Returns configuration created with test parameters dependent on use-case.
 
-    E.g. create_simple_params(usecase="nss_v1",
+    E.g. create_simple_params(usecase="nss-v1",
                             output_dir="./output",
                             dataset_path="path/to/dataset")
     """

--- a/tests/usecases/nfru/unit/test_nfru_dataset.py
+++ b/tests/usecases/nfru/unit/test_nfru_dataset.py
@@ -762,7 +762,7 @@ class TestNFRUDataset(unittest.TestCase):  # pylint: disable=too-many-public-met
     def test_raises_when_sequence_has_fewer_than_minimum_frames(self):
         """A 4-frame sequence cannot satisfy the 5-frame sliding-window minimum."""
         dataset_path = Path("tests/datasets/test_nfru_4f_short")
-        params = create_simple_params(usecase="nfru", dataset_path=str(dataset_path))
+        params = create_simple_params(usecase="nfru-v1", dataset_path=str(dataset_path))
         params.dataset.path.test = dataset_path
         params.dataset.health_check = False
 

--- a/tests/usecases/nfru/unit/test_nfru_v1_model.py
+++ b/tests/usecases/nfru/unit/test_nfru_v1_model.py
@@ -94,7 +94,7 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
         mv_similarity_threshold: Optional[float] = None,
     ) -> None:
         """Create a fresh NFRU model instance configured for the given batch size."""
-        params = create_simple_params(usecase="nfru")
+        params = create_simple_params(usecase="nfru-v1")
         params_dict = params.model_dump(mode="json")
 
         params_dict["dataset"]["health_check"] = False
@@ -415,14 +415,14 @@ class TestNFRUV1Model(BaseGPUMemoryTest):
 
     def test_model_requires_color_preprocessing(self) -> None:
         """NFRU v1 should reject configs without explicit color preprocessing."""
-        params = create_simple_params(usecase="nfru")
+        params = create_simple_params(usecase="nfru-v1")
         params.dataset.color_preprocessing = None
         with self.assertRaisesRegex(ValueError, "dataset.color_preprocessing"):
             create_model(params, self.device)
 
     def test_model_requires_all_color_preprocessing_splits(self) -> None:
         """NFRU v1 should reject configs missing validation/test/train splits."""
-        params = create_simple_params(usecase="nfru")
+        params = create_simple_params(usecase="nfru-v1")
         if params.dataset.color_preprocessing is None:
             self.fail("Expected color_preprocessing config in simple NFRU params")
         params.dataset.color_preprocessing.validation = None
@@ -545,7 +545,7 @@ class TestNFRUV1DynamicMaskConfig(unittest.TestCase):
 
     def test_slang_module_loading(self) -> None:
         """Test the Slang module loading configuration."""
-        params = create_simple_params(usecase="nfru")
+        params = create_simple_params(usecase="nfru-v1")
         params.model_train_eval_mode = TrainEvalMode.FP32
         network = create_model(params, torch.device("cpu")).network
 
@@ -566,7 +566,7 @@ class TestNFRUV1DynamicMaskConfig(unittest.TestCase):
         Test that the correct previous dynamic mask function is returned for
         each value of the parameters.
         """
-        params = create_simple_params(usecase="nfru")
+        params = create_simple_params(usecase="nfru-v1")
         params.model_train_eval_mode = TrainEvalMode.FP32
         network = create_model(params, torch.device("cpu")).network
         slang = Mock()

--- a/tests/usecases/nfru/unit/test_pre_processing.py
+++ b/tests/usecases/nfru/unit/test_pre_processing.py
@@ -34,7 +34,7 @@ class TestPreProcess(BaseGPUMemoryTest):
         torch.manual_seed(1)
         torch.cuda.manual_seed(1)
 
-        self.params = create_simple_params(usecase="nfru")
+        self.params = create_simple_params(usecase="nfru-v1")
         self.params.model_train_eval_mode = TrainEvalMode.FP32
 
         self.model = create_model(self.params, self.device)
@@ -132,7 +132,7 @@ class TestNFRUPreprocessGolden(BaseGPUMemoryTest):
         torch.manual_seed(1)
         torch.cuda.manual_seed(1)
 
-        self.params = create_simple_params(usecase="nfru")
+        self.params = create_simple_params(usecase="nfru-v1")
         self.params.model_train_eval_mode = TrainEvalMode.FP32
 
         self.model = create_model(self.params, self.device)

--- a/tests/usecases/nss/unit/nss_v1_test_utils.py
+++ b/tests/usecases/nss/unit/nss_v1_test_utils.py
@@ -37,7 +37,7 @@ def load_nss_v1_golden(filename: str, device: torch.device) -> dict:
 def create_nss_v1_test_params(quality: str):
     """Create shared NSS v1 params used by unit tests."""
 
-    params = create_simple_params(usecase="nss_v1")
+    params = create_simple_params(usecase="nss-v1")
     params.model_train_eval_mode = TrainEvalMode.FP32
     params.model.quality = quality
     params.model.recurrent_samples = 2

--- a/tests/usecases/nss/unit/test_nss_v1_checkpoint_loading.py
+++ b/tests/usecases/nss/unit/test_nss_v1_checkpoint_loading.py
@@ -33,14 +33,14 @@ class TestNSSV1CheckpointLoading(unittest.TestCase):
     def _create_fake_checkpoints(self) -> tuple[Path, Path]:
         """Create fake high and mid/low checkpoints from model state dicts."""
 
-        mid_params = create_simple_params(usecase="nss_v1")
+        mid_params = create_simple_params(usecase="nss-v1")
         mid_params.model.quality = "mid"
         mid_params.model_train_eval_mode = TrainEvalMode.FP32
 
         mid_model = create_model(mid_params, self.device)
         mid_state = mid_model.state_dict()
 
-        high_params = create_simple_params(usecase="nss_v1")
+        high_params = create_simple_params(usecase="nss-v1")
         high_params.model.quality = "high"
         high_params.model_train_eval_mode = TrainEvalMode.FP32
 
@@ -58,7 +58,7 @@ class TestNSSV1CheckpointLoading(unittest.TestCase):
     def test_high_ckpt_prunes_to_mid_low(self) -> None:
         """Validate high checkpoint loads as 6x6 for high and prunes to 4x4 for mid."""
 
-        high_params = create_simple_params(usecase="nss_v1")
+        high_params = create_simple_params(usecase="nss-v1")
         high_params.model.quality = "high"
         high_params.model_train_eval_mode = TrainEvalMode.FP32
 
@@ -72,7 +72,7 @@ class TestNSSV1CheckpointLoading(unittest.TestCase):
 
         self.assertEqual(high_state["autoencoder.kpn_params.conv2d.bias"].shape[0], 36)
 
-        mid_params = create_simple_params(usecase="nss_v1")
+        mid_params = create_simple_params(usecase="nss-v1")
         mid_params.model.quality = "mid"
         mid_params.model_train_eval_mode = TrainEvalMode.FP32
 
@@ -89,7 +89,7 @@ class TestNSSV1CheckpointLoading(unittest.TestCase):
     def test_mid_low_ckpt_loads_into_mid_model(self) -> None:
         """Validate that a mid/low quality checkpoint loads into a mid quality model."""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.quality = "mid"
         params.model_train_eval_mode = TrainEvalMode.FP32
 
@@ -101,7 +101,7 @@ class TestNSSV1CheckpointLoading(unittest.TestCase):
     def test_mid_low_ckpt_rejected_by_high_model(self) -> None:
         """Validate that loading a mid/low quality checkpoint into a high quality model fails."""
 
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.quality = "high"
         params.model_train_eval_mode = TrainEvalMode.FP32
 

--- a/tests/usecases/nss/unit/test_nss_v1_dataset.py
+++ b/tests/usecases/nss/unit/test_nss_v1_dataset.py
@@ -26,7 +26,7 @@ class TestNSSV1Dataset(unittest.TestCase):
     def setUp(self):
         """Set up a default NSS v1 training config."""
         self.params = create_simple_params(
-            usecase="nss_v1", dataset_path=Path("tests/usecases/nss/datasets/train")
+            usecase="nss-v1", dataset_path=Path("tests/usecases/nss/datasets/train")
         )
         self.params.model.recurrent_samples = 4
         self.params.dataset.gt_augmentation = False
@@ -73,7 +73,7 @@ class TestNSSV1Dataset(unittest.TestCase):
         save_file(tensors, new_safetensor_path, metadata=original_metadata)
 
         params = create_simple_params(
-            usecase="nss_v1",
+            usecase="nss-v1",
             dataset_path=new_safetensor_dir,
         )
         params.dataset.exposure = None
@@ -130,7 +130,7 @@ class TestNSSV1Dataset(unittest.TestCase):
             save_file(tensors, new_safetensor_path, metadata=original_metadata)
 
             params_json = create_simple_params(
-                usecase="nss_v1", dataset_path=dataset_dir
+                usecase="nss-v1", dataset_path=dataset_dir
             ).model_dump(mode="json")
             params = validate_params(params_json)
             params.model.recurrent_samples = 4
@@ -155,7 +155,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
     def test_windows_skip_mid_sequence_cuts(self):
         """Sliding windows stop before mid-span cuts but still start on the cut."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.recurrent_samples = 4
 
         flags = [False, False, False, False, True, False, False, False, False, False]
@@ -173,7 +173,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
     def test_seq_id_changes_per_segment_in_test_mode(self):
         """Sequence hashes change at each cut when iterating in TEST mode."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.recurrent_samples = 4
 
         flags = [False, False, False, False, True, False, False, False]
@@ -199,7 +199,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
     def test_seq_tensor_resets_when_camera_cut_true(self):
         """`seq` should flip only when the camera_cut flag is set."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.recurrent_samples = 4
 
         flags = [False, False, True, False, False]
@@ -220,7 +220,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
     def test_short_camera_cut_segments_are_dropped(self):
         """Segments shorter than recurrent_samples should not emit windows."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.recurrent_samples = 4
 
         flags = [
@@ -249,7 +249,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
     def test_legacy_file_without_camera_cut(self):
         """Legacy files without camera_cut should be treated as a single sequence."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.recurrent_samples = 4
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -266,7 +266,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
     def test_short_capture_logs_warning_and_is_skipped(self):
         """Captures shorter than recurrent_samples emit a warning and are ignored."""
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.recurrent_samples = 4
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -300,7 +300,7 @@ class TestNSSV1Dataset(unittest.TestCase):
         """Test recurrent_samples validation and mode-specific behavior."""
         with self.subTest("train_mode_two_recurrent_samples"):
             params = create_simple_params(
-                usecase="nss_v1",
+                usecase="nss-v1",
                 dataset_path=Path("tests/usecases/nss/datasets/train"),
             )
             params.model.recurrent_samples = 2
@@ -313,13 +313,12 @@ class TestNSSV1Dataset(unittest.TestCase):
 
         with self.subTest("train_mode_missing_recurrent_samples"):
             config_json = create_simple_params(
-                usecase="nss_v1",
+                usecase="nss-v1",
                 dataset_path=Path("tests/usecases/nss/datasets/train"),
             ).model_dump(mode="json")
             config_json["model"] = {
                 "name": "my_custom_model",
                 "model_source": "custom",
-                "version": "1",
                 "quality": "high",
             }
             params = validate_params(config_json)
@@ -335,7 +334,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
         with self.subTest("train_mode_raise_recurrent_samples_less_than_two"):
             params = create_simple_params(
-                usecase="nss_v1",
+                usecase="nss-v1",
                 dataset_path=Path("tests/usecases/nss/datasets/train"),
             )
             params.model.recurrent_samples = 1
@@ -349,7 +348,7 @@ class TestNSSV1Dataset(unittest.TestCase):
 
         with self.subTest("test_mode_sets_single_sample"):
             params = create_simple_params(
-                usecase="nss_v1",
+                usecase="nss-v1",
                 dataset_path=Path("tests/usecases/nss/datasets/train"),
             )
             params.model.recurrent_samples = 10
@@ -374,7 +373,7 @@ class TestNSSV1DatasetGolden(unittest.TestCase):
         )
 
         params = create_simple_params(
-            usecase="nss_v1", dataset_path=Path("tests/usecases/nss/datasets/train")
+            usecase="nss-v1", dataset_path=Path("tests/usecases/nss/datasets/train")
         )
         params.model.quality = "high"
         params.model.recurrent_samples = 2

--- a/tests/usecases/nss/unit/test_nss_v1_model.py
+++ b/tests/usecases/nss/unit/test_nss_v1_model.py
@@ -9,7 +9,7 @@ import torch
 import torch.nn.functional as F
 from pydantic import ValidationError
 
-from ng_model_gym.core.config.config_model import NSSModelSettings
+from ng_model_gym.core.config.config_model import NSSV1ModelSettings
 from ng_model_gym.core.data.data_utils import tonemap_forward
 from ng_model_gym.core.model import BaseNGModel, create_model
 from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
@@ -84,7 +84,7 @@ class _NSSV1ModelTestMixin:
         """Set up shared NSS v1 model test state."""
 
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        self.params = create_simple_params(usecase="nss_v1")
+        self.params = create_simple_params(usecase="nss-v1")
         self.params.model_train_eval_mode = TrainEvalMode.FP32
         self.params.train.batch_size = 2
         self.params.model.recurrent_samples = 4
@@ -102,12 +102,11 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
         self._init_nss_v1_model_test_state()
 
     def test_config_accepts_non_integer_nss_v1_scale(self) -> None:
-        """NSS config accepts numeric scales greater than 1.0."""
+        """NSS v1 config accepts numeric scales greater than 1.0."""
 
-        settings = NSSModelSettings(
-            name="nss",
+        settings = NSSV1ModelSettings(
+            name="nss-v1",
             model_source="prebuilt",
-            version="1",
             scale=1.5,
             recurrent_samples=4,
             quality="high",
@@ -121,7 +120,7 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
         for scale in (1.0, 0.75):
             with self.subTest(scale=scale):
                 with self.assertRaisesRegex(ValidationError, "greater than 1"):
-                    NSSModelSettings(
+                    NSSV1ModelSettings(
                         name="nss",
                         model_source="prebuilt",
                         version="1",
@@ -131,12 +130,11 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
                     )
 
     def test_config_coerces_integer_nss_v1_scale(self) -> None:
-        """NSS config accepts integer scales and stores them as floats."""
+        """NSS v1 config accepts integer scales and stores them as floats."""
 
-        settings = NSSModelSettings(
-            name="nss",
+        settings = NSSV1ModelSettings(
+            name="nss-v1",
             model_source="prebuilt",
-            version="1",
             scale=2,
             recurrent_samples=4,
             quality="high",
@@ -148,10 +146,9 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
     def test_config_defaults_nss_v1_runtime_shader_variants_to_enabled(self) -> None:
         """NSS v1 config enables runtime shader variant toggles by default."""
 
-        settings = NSSModelSettings(
-            name="nss",
+        settings = NSSV1ModelSettings(
+            name="nss-v1",
             model_source="prebuilt",
-            version="1",
             scale=2.0,
             recurrent_samples=4,
             quality="high",
@@ -163,10 +160,9 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
     def test_config_accepts_disabled_nss_v1_runtime_shader_variants(self) -> None:
         """NSS v1 config accepts explicit disabled runtime shader variants."""
 
-        settings = NSSModelSettings(
-            name="nss",
+        settings = NSSV1ModelSettings(
+            name="nss-v1",
             model_source="prebuilt",
-            version="1",
             scale=2.0,
             recurrent_samples=4,
             quality="high",

--- a/tests/usecases/nss/unit/test_nss_v1_post_processing.py
+++ b/tests/usecases/nss/unit/test_nss_v1_post_processing.py
@@ -275,7 +275,7 @@ class TestNSSV1PostprocessGolden(BaseGPUMemoryTest):
 
     @staticmethod
     def _create_model(quality, device):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.quality = quality
         params.model.recurrent_samples = 2
         params.train.batch_size = 2

--- a/tests/usecases/nss/unit/test_nss_v1_pre_processing.py
+++ b/tests/usecases/nss/unit/test_nss_v1_pre_processing.py
@@ -331,7 +331,7 @@ class TestNSSV1PreprocessGolden(BaseGPUMemoryTest):
 
     @staticmethod
     def _create_model(quality, device, scale=2.0):
-        params = create_simple_params(usecase="nss_v1")
+        params = create_simple_params(usecase="nss-v1")
         params.model.quality = quality
         params.model.scale = scale
         params.model.recurrent_samples = 2


### PR DESCRIPTION
* Model versions now included in model name
* Update documentation to use new model names
* Bump CONFIG_SCHEMA_VERSION to 9
* Version param removed from NFRU and NSS templates

Signed-off-by: Ciara Sookarry <ciara.sookarry@arm.com>
Change-Id: Ie1780bbabd16b33c62fa6b652b49459f086ff4eb