### PR TITLE
Remove `version` attribute from model classes

### DIFF
--- a/docs/adding-custom-models-and-datasets.md
+++ b/docs/adding-custom-models-and-datasets.md
@@ -14,7 +14,7 @@ There are two common ways to add models and datasets:
 
 #### Modifying a prebuilt model
 
-If you copy a prebuilt model (such as NSS), modify the class decorator to register it under a new name (for example, `MyNSSModel`). Use the prebuilt model config, set `model.name/model.version` to your new registration, and keep `model_source: "prebuilt"`.
+If you copy a prebuilt model (such as NSS), modify the class decorator to register it under a new name (for example, `MyNSSModel`). Use the prebuilt model config, set `model.name` to your new registration, and keep `model_source: "prebuilt"`.
 
 ```bash
 ng-model-gym init nss-v1 [save_dir]
@@ -23,9 +23,8 @@ ng-model-gym init nss-v1 [save_dir]
 ```json
 {
   "model": {
-    "name": "nss",
+    "name": "my-nss-model-v1",
     "model_source": "prebuilt",
-    "version": "1",
     "scale": 2.0,
     "recurrent_samples": 16
   },
@@ -40,7 +39,7 @@ If you are adding a new model or dataset from scratch, use the custom template a
 
 #### Registering a new model
 
-To add a new model, mark the model class with the `@register_model()` decorator, giving the name and optional version to register it under. Models must inherit from the [`BaseNGModel`](../src/ng_model_gym/core/model/base_ng_model.py) class, implement any required methods, and their constructors must accept `params` as an argument.
+To add a new model, mark the model class with the `@register_model()` decorator, giving the name to register it under. Models must inherit from the [`BaseNGModel`](../src/ng_model_gym/core/model/base_ng_model.py) class, implement any required methods, and their constructors must accept `params` as an argument.
 
 ```python
 from ng_model_gym.core.model.base_ng_model import BaseNGModel
@@ -48,7 +47,7 @@ from ng_model_gym.core.model.model_registry import register_model
 from ng_model_gym.core.config.config_model import ConfigModel
 
 
-@register_model(name="name", version="version")
+@register_model(name="name")
 class NewModel(BaseNGModel):
     def __init__(self, params: ConfigModel):
         super().__init__(params)
@@ -111,9 +110,8 @@ Custom model configs must set `"model_source": "custom"`. This allows for extra 
 ```json
 {
   "model": {
-    "name": "registered_model_name",
+    "name": "registered-model-name-v1",
     "model_source": "custom",
-    "version": "1",
     "my_field": "value",
     "my_field2": "value"
   },

--- a/src/ng_model_gym/core/config/config_model.py
+++ b/src/ng_model_gym/core/config/config_model.py
@@ -2,8 +2,10 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
+import re
+import warnings
 from numbers import Real
-from typing import Annotated, Any, List, Literal, Optional, Union
+from typing import Annotated, Any, ClassVar, List, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -150,7 +152,6 @@ class BaseModelSettings(PydanticConfigModel):
     """Model configuration"""
 
     name: str = Field(description="Model name")
-    version: Optional[str] = Field(description="Model version", default=None)
 
 
 class PrebuiltModelSettingsBase(BaseModelSettings):
@@ -539,19 +540,60 @@ class Train(PydanticConfigModel):
 class ConfigModel(PydanticConfigModel):
     """Pydantic model representing configuration file"""
 
+    _MODEL_VERSION_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
+        r"^(?P<base>.+)-v(?P<version>[^-]+)$"
+    )
+
+    @classmethod
+    def _canonicalise_model_identifier(
+        cls, name: str, version: Any, model_source: str
+    ) -> str:
+        """Return the model name after folding deprecated model.version input."""
+        canonical_name = name.strip()
+        if model_source == "prebuilt":
+            canonical_name = canonical_name.lower()
+
+        legacy_version = "" if version is None else str(version).strip()
+        if not legacy_version:
+            return canonical_name
+
+        warnings.warn(
+            "model.version is deprecated; encode the version in model.name instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+
+        match = cls._MODEL_VERSION_PATTERN.fullmatch(canonical_name)
+        if match:
+            encoded_version = match.group("version")
+            if encoded_version.lower() != legacy_version.lower():
+                raise PydanticCustomError(
+                    "ModelVersionConflict",
+                    "model.version conflicts with the version encoded in model.name. "
+                    f"Received model.name={name!r} and model.version={legacy_version!r}.",
+                )
+            return canonical_name
+
+        return f"{canonical_name}-v{legacy_version}"
+
     @model_validator(mode="before")
     @classmethod
     def _normalise_model_name(cls, values: dict):
-        """Normalise pre-built model names to lowercase."""
+        """Normalise model names and fold deprecated model.version input."""
 
         if isinstance(values, dict):
             model = values.get("model")
 
-            if isinstance(model, dict) and model.get("model_source") == "prebuilt":
+            if isinstance(model, dict):
                 name = model.get("name")
+                model_source = model.get("model_source")
 
-                if isinstance(name, str):
-                    model["name"] = name.lower()
+                if isinstance(name, str) and model_source in {"prebuilt", "custom"}:
+                    model["name"] = cls._canonicalise_model_identifier(
+                        name=name,
+                        version=model.pop("version", None),
+                        model_source=model_source,
+                    )
 
         return values
 

--- a/src/ng_model_gym/core/config/config_utils.py
+++ b/src/ng_model_gym/core/config/config_utils.py
@@ -43,18 +43,12 @@ class TemplateInfo:
 def _get_template_key_and_name(data: dict) -> Tuple[str, str]:
     """Return the normalized lookup key and display name for a config template."""
     model = data.get("model", {})
-    model_name = str(model.get("name")).strip()
+    model_name = str(model.get("name", "")).strip()
 
     if model.get("model_source") == "custom":
         return "custom", "custom"
 
-    model_key = model_name.lower()
-    model_version = str(model.get("version", "")).strip()
-    if model_version and model_version != "1":
-        version_suffix = f"_v{model_version}"
-        return f"{model_key}{version_suffix}", f"{model_name}{version_suffix}"
-
-    return model_key, model_name
+    return model_name.lower(), model_name
 
 
 def _discover_config_templates() -> Dict[str, List[TemplateInfo]]:

--- a/src/ng_model_gym/core/config/custom_template.json
+++ b/src/ng_model_gym/core/config/custom_template.json
@@ -3,7 +3,6 @@
     "model": {
         "name": "<NAME_OF_REGISTERED_MODEL>",
         "model_source": "custom",
-        "version": "<>",
         "custom_param": ""
     },
     "dataset": {

--- a/src/ng_model_gym/core/config/schema_config.json
+++ b/src/ng_model_gym/core/config/schema_config.json
@@ -19,18 +19,6 @@
                             "const": "nss-v1",
                             "type": "string"
                         },
-                        "version": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "default": null,
-                            "description": "Model version"
-                        },
                         "model_source": {
                             "const": "prebuilt",
                             "type": "string"
@@ -91,18 +79,6 @@
                             "const": "nfru-v1",
                             "type": "string"
                         },
-                        "version": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "default": null,
-                            "description": "Model version"
-                        },
                         "model_source": {
                             "const": "prebuilt",
                             "type": "string"
@@ -146,18 +122,6 @@
                 "name": {
                     "description": "Model name",
                     "type": "string"
-                },
-                "version": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "default": null,
-                    "description": "Model version"
                 },
                 "model_source": {
                     "const": "custom",

--- a/src/ng_model_gym/core/export/model_export.py
+++ b/src/ng_model_gym/core/export/model_export.py
@@ -367,9 +367,7 @@ def executorch_vgf_export(
     model_forward_input = tree_map(to_cpu, model_forward_input)
     model_forward_input = tree_map(to_channels_last, model_forward_input)
 
-    model_version = getattr(model, "version", None)
-
-    model_key = get_model_key(params.model.name, model_version)
+    model_key = get_model_key(params.model.name)
 
     metadata_path = (
         Path(params.output.export.vgf_output_dir)

--- a/src/ng_model_gym/core/model/model_factory.py
+++ b/src/ng_model_gym/core/model/model_factory.py
@@ -16,12 +16,11 @@ logger = logging.getLogger(__name__)
 
 def get_model_from_config(params: ConfigModel) -> Type[BaseNGModel]:
     """Return the registered model class from the model registry,
-    using the name (and optionally version) supplied in the config file."""
+    using the name supplied in the config file."""
 
     model_name = params.model.name
-    model_version = params.model.version if params.model.version else None
 
-    model_key = get_model_key(model_name, model_version)
+    model_key = get_model_key(model_name)
 
     model = MODEL_REGISTRY.get(model_key)
 

--- a/src/ng_model_gym/core/model/model_registry.py
+++ b/src/ng_model_gym/core/model/model_registry.py
@@ -2,7 +2,7 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 import inspect
-from typing import Optional, Type
+from typing import Type
 
 from torch import nn
 
@@ -45,17 +45,17 @@ MODEL_REGISTRY: Registry[BaseNGModel] = Registry(
 )
 
 
-def get_model_key(name: str, version: Optional[str] = None) -> str:
-    """Return the model key based on the name and optional version."""
-    key = f"{name}-v{version}" if version is not None else name
+def get_model_key(name: str) -> str:
+    """Return the model key based on the name."""
+    key = name.lower()
 
-    return key.lower()
+    return key
 
 
-def register_model(name: str, version: Optional[str] = None):
+def register_model(name: str):
     """
     Helper function to add a new model to the model registry,
-    using a new unique identifier as the key, with optional version.
+    using a new unique identifier as the key.
 
     Example::
 
@@ -63,6 +63,6 @@ def register_model(name: str, version: Optional[str] = None):
         class NSS_Model(BaseNGModel)
             pass
     """
-    key = get_model_key(name, version)
+    key = get_model_key(name)
 
     return MODEL_REGISTRY.register(key)

--- a/tests/core/unit/model/test_model_factory.py
+++ b/tests/core/unit/model/test_model_factory.py
@@ -125,20 +125,6 @@ class TestModelFactory(unittest.TestCase):
         ):
             get_model_from_config(self.params)
 
-    def test_error_on_unregistered_model_version(self):
-        """Test loading a model class with a version that isn't registered."""
-
-        # Override model version from params
-        self.params.model.version = "unregistered_version"
-
-        model_key = get_model_key(self.params.model.name, self.params.model.version)
-
-        with self.assertRaisesRegex(
-            KeyError,
-            rf"Model {model_key} is not registered",
-        ):
-            get_model_from_config(self.params)
-
     def test_create_model(self):
         """Test initialising the model from the registered class."""
 

--- a/tests/scripts/test_config.py
+++ b/tests/scripts/test_config.py
@@ -221,11 +221,41 @@ class TestConfig(unittest.TestCase):
                 json.dump(user_config, temp_file)
                 temp_path = Path(temp_file.name)
 
-            loaded = load_config_file(temp_path)
+            with self.assertWarnsRegex(DeprecationWarning, "model.version"):
+                loaded = load_config_file(temp_path)
 
-            self.assertEqual(loaded.model.name, "my_model")
+            self.assertEqual(loaded.model.name, "my_model-v1")
             self.assertEqual(loaded.model.model_source, "custom")
             self.assertEqual(loaded.model.custom_field, 0.1)
+
+    def test_legacy_prebuilt_model_version_is_folded_into_name(self):
+        """Test legacy model.version is folded into model.name for prebuilt models."""
+
+        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
+        user_config["model"]["name"] = "NSS"
+        user_config["model"]["version"] = "1"
+
+        with self.assertWarnsRegex(DeprecationWarning, "model.version"):
+            loaded_config = config_model.ConfigModel.model_validate(user_config)
+
+        self.assertEqual(loaded_config.model.name, "nss-v1")
+        self.assertNotIn("version", loaded_config.model.model_dump(mode="json"))
+
+    def test_legacy_model_version_conflict_is_rejected(self):
+        """Test conflicting legacy model.version and versioned model.name is rejected."""
+
+        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
+        user_config["model"]["name"] = "NSS-v1"
+        user_config["model"]["version"] = "2"
+
+        with self.assertWarnsRegex(DeprecationWarning, "model.version"):
+            with self.assertRaises(ValidationError) as exc:
+                config_model.ConfigModel.model_validate(user_config)
+
+        self.assertIn(
+            "model.version conflicts with the version encoded in model.name",
+            str(exc.exception),
+        )
 
     def test_model_specific_config_classes_in_union_type(self):
         """


### PR DESCRIPTION
* Change register_model() decorator to use model name only
* Remove version from BaseModelSettings and template configs
* Add logic to support legacy configs that still use model.version
* Add DeprecationWarning if model.version used

Signed-off-by: Ciara Sookarry <ciara.sookarry@arm.com>
Change-Id: Ide839093a4548e3dfdc61e1f96c48d080ebbc716
