### PR TITLE
Reduce NSS v1 recurrent output memory

### DIFF
--- a/src/ng_model_gym/core/loss/losses.py
+++ b/src/ng_model_gym/core/loss/losses.py
@@ -23,6 +23,14 @@ TensorData = Union[torch.Tensor, Dict[str, torch.Tensor], List[torch.Tensor]]
 class LossV1(torch.nn.Module):
     """NSS v1 recurrent loss."""
 
+    required_context_keys = (
+        "output",
+        "out_filtered",
+        "temporal_params",
+        "disocclusion_mask",
+        "reset_event",
+    )
+
     def __init__(
         self,
         recurrent_samples: int,

--- a/src/ng_model_gym/core/trainer/trainer.py
+++ b/src/ng_model_gym/core/trainer/trainer.py
@@ -135,6 +135,17 @@ class Trainer:
     def _set_up_torch_compile(self) -> None:
         """Set up optional torch.compile for training"""
 
+        # Only keep model outputs required by the training loss
+        if hasattr(self.model, "required_context_keys"):
+            required_context_keys = getattr(
+                self.criterion, "required_context_keys", None
+            )
+            setattr(
+                self.model,
+                "required_context_keys",
+                None if required_context_keys is None else tuple(required_context_keys),
+            )
+
         compile_enabled = self.params.train.compile
         if compile_enabled:
             torch._dynamo.config.cache_size_limit = max(

--- a/src/ng_model_gym/usecases/nss/model/model_v1.py
+++ b/src/ng_model_gym/usecases/nss/model/model_v1.py
@@ -65,6 +65,7 @@ class NSSV1Model(BaseNGModel):
 
         self.scale = self.params.model.scale
         self.recurrent_samples = self.params.model.recurrent_samples
+        self.required_context_keys: Optional[tuple[str, ...]] = None
         self.gt_history_augmentation = bool(self.params.model.gt_history_augmentation)
         self.gt_history_augmentation_chance = float(
             self.params.model.gt_history_augmentation_chance
@@ -142,7 +143,13 @@ class NSSV1Model(BaseNGModel):
             self.update_buffers(inputs, y_pred)
 
             for key, value in y_pred.items():
-                outputs.setdefault(key, []).append(value)
+                should_stack = (
+                    self.required_context_keys is None
+                    or key == "output"
+                    or key in self.required_context_keys
+                )
+                if should_stack:
+                    outputs.setdefault(key, []).append(value)
 
         stacked_outputs = {
             key: torch.stack(value, dim=1) for key, value in outputs.items()

--- a/tests/core/unit/trainer/test_trainer.py
+++ b/tests/core/unit/trainer/test_trainer.py
@@ -8,7 +8,7 @@ import unittest
 from datetime import datetime
 from pathlib import Path
 from types import MethodType
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import torch
 from torch import nn, optim
@@ -166,6 +166,54 @@ class TestTrainerMethods(unittest.TestCase):
 
         called_epochs = [c.args[0] for c in self.mock_trainer.validate.call_args_list]
         self.assertEqual(called_epochs, [3, 6, 9])
+
+    def test_compile_setup_configures_required_context_before_compile(self):
+        """Compile setup fixes the model output contract from the active loss."""
+
+        trainer = Mock(spec=Trainer)
+        trainer.params = create_simple_params(usecase="nss-v1")
+        trainer.params.train.compile = False
+        trainer.model = TinyModel()
+        trainer.model.required_context_keys = None
+        trainer.criterion = Mock()
+        trainer.criterion.required_context_keys = (
+            "output",
+            "out_filtered",
+        )
+        model_context_at_compile = []
+
+        def compile_module(module, **_kwargs):
+            if module is trainer.model:
+                model_context_at_compile.append(trainer.model.required_context_keys)
+            return module
+
+        with patch("torch.compile", side_effect=compile_module) as compile_:
+            Trainer._set_up_torch_compile(trainer)
+
+            self.assertEqual(
+                model_context_at_compile,
+                [("output", "out_filtered")],
+            )
+            self.assertIs(compile_.call_args_list[0].args[0], trainer.model)
+            self.assertEqual(
+                trainer.model.required_context_keys,
+                trainer.criterion.required_context_keys,
+            )
+            self.assertIsInstance(trainer.model.required_context_keys, tuple)
+            self.assertIs(
+                trainer.model.required_context_keys, model_context_at_compile[0]
+            )
+            self.assertIs(trainer._training_model, trainer.model)
+            self.assertIs(trainer._training_loss, trainer.criterion)
+
+            trainer.criterion = nn.L1Loss()
+            Trainer._set_up_torch_compile(trainer)
+
+        self.assertEqual(model_context_at_compile, [("output", "out_filtered"), None])
+        self.assertIsNone(trainer.model.required_context_keys)
+        self.assertIs(trainer._training_model, trainer.model)
+        self.assertIs(trainer._training_loss, trainer.criterion)
+        self.assertEqual(compile_.call_count, 4)
 
     def test_train_calls_validate_on_specific_epochs(self):
         """Ensure Trainer.train() only triggers validate() on configured epochs"""

--- a/tests/usecases/nss/unit/test_nss_v1_model.py
+++ b/tests/usecases/nss/unit/test_nss_v1_model.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from ng_model_gym.core.config.config_model import NSSV1ModelSettings
 from ng_model_gym.core.data.data_utils import tonemap_forward
+from ng_model_gym.core.loss import LossV1
 from ng_model_gym.core.model import BaseNGModel, create_model
 from ng_model_gym.core.utils.enum_definitions import TrainEvalMode
 from ng_model_gym.usecases.nss.model.model_blocks_v1 import AutoEncoderV1
@@ -801,6 +802,60 @@ class TestNSSV1Model(  # pylint: disable=too-many-public-methods
             torch.ones_like(model_out["reset_event"][:, 1, ...]),
             rtol=0,
             atol=0,
+        )
+
+    def test_loss_aware_forward_stacks_only_required_context(self) -> None:
+        """NSS v1 only stacks recurrent outputs required by its active loss."""
+
+        model = create_model(self.params, self.device)
+
+        def core_forward(inputs):
+            output_value = 1.0
+            output_linear = torch.full_like(inputs["history"], output_value)
+            return {
+                "output": output_linear,
+                "output_linear": output_linear,
+                "out_filtered": output_linear,
+                "temporal_params": torch.full_like(
+                    inputs["temporal_params_tm1"], output_value
+                ),
+                "disocclusion_mask": torch.full_like(inputs["depth"], output_value),
+                "derivative": torch.full_like(inputs["derivative_tm1"], output_value),
+                "ground_truth": torch.full_like(
+                    inputs["ground_truth_linear"], output_value
+                ),
+                "input_color": torch.full_like(inputs["colour_linear"], output_value),
+            }
+
+        model.core_forward = core_forward
+        model.required_context_keys = LossV1.required_context_keys
+        inputs = self._data_creator_helper(8, 8, 16, 16, recurrence=2)
+
+        with patch(
+            "ng_model_gym.usecases.nss.model.model_v1.torch.stack",
+            wraps=torch.stack,
+        ) as stack:
+            model_out = model(inputs)
+
+        self.assertEqual(stack.call_count, 5)
+        self.assertEqual(set(model_out), set(LossV1.required_context_keys) | {"motion"})
+        for key in (
+            "output_linear",
+            "derivative",
+            "ground_truth",
+            "input_color",
+        ):
+            self.assertNotIn(key, model_out)
+        for key in LossV1.required_context_keys:
+            self.assertEqual(model_out[key].shape[1], 2)
+        self.assertIs(model_out["motion"], inputs["motion"])
+        torch.testing.assert_close(
+            model_out["reset_event"][:, 0, ...],
+            torch.zeros_like(model_out["reset_event"][:, 0, ...]),
+        )
+        torch.testing.assert_close(
+            model_out["reset_event"][:, 1, ...],
+            torch.ones_like(model_out["reset_event"][:, 1, ...]),
         )
 
     def test_forward_overwrites_loss_context_keys(self) -> None:


### PR DESCRIPTION
* Specify required outputs of NSS in LossV1
* Only stack tensors used by the loss

Signed-off-by: Ayaan Masood <ayaan.masood@arm.com>
Change-Id: I43d690dce0d5cd46733ddf8a3cdc2d29999aa44d
