### PR TITLE
Remove support for older configs

### DIFF
--- a/src/ng_model_gym/core/config/config_model.py
+++ b/src/ng_model_gym/core/config/config_model.py
@@ -2,10 +2,8 @@
 # its affiliates <open-source-office@arm.com></text>
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
-import re
-import warnings
 from numbers import Real
-from typing import Annotated, Any, ClassVar, List, Literal, Optional, Union
+from typing import Annotated, Any, List, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -29,7 +27,7 @@ from ng_model_gym.core.utils.enum_definitions import (
 
 # pylint: disable=line-too-long
 
-CONFIG_SCHEMA_VERSION = "9"
+CONFIG_SCHEMA_VERSION = "10"
 
 # Pydantic models representing the configuration file structure.
 # For fields which are not core to all model types (e.g. recurrent_samples),
@@ -558,61 +556,24 @@ class Train(PydanticConfigModel):
 class ConfigModel(PydanticConfigModel):
     """Pydantic model representing configuration file"""
 
-    _MODEL_VERSION_PATTERN: ClassVar[re.Pattern[str]] = re.compile(
-        r"^(?P<base>.+)-v(?P<version>[^-]+)$"
-    )
-
-    @classmethod
-    def _canonicalise_model_identifier(
-        cls, name: str, version: Any, model_source: str
-    ) -> str:
-        """Return the model name after folding deprecated model.version input."""
-        canonical_name = name.strip()
-        if model_source == "prebuilt":
-            canonical_name = canonical_name.lower()
-
-        legacy_version = "" if version is None else str(version).strip()
-        if not legacy_version:
-            return canonical_name
-
-        warnings.warn(
-            "model.version is deprecated; encode the version in model.name instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-
-        match = cls._MODEL_VERSION_PATTERN.fullmatch(canonical_name)
-        if match:
-            encoded_version = match.group("version")
-            if encoded_version.lower() != legacy_version.lower():
-                raise PydanticCustomError(
-                    "ModelVersionConflict",
-                    "model.version conflicts with the version encoded in model.name. "
-                    f"Received model.name={name!r} and model.version={legacy_version!r}.",
-                )
-            return canonical_name
-
-        return f"{canonical_name}-v{legacy_version}"
-
     @model_validator(mode="before")
     @classmethod
     def _normalise_model_name(cls, values: dict):
-        """Normalise model names and fold deprecated model.version input."""
+        """
+        Normalise model names.
+        All names are stripped of leading and trailing whitespace.
+        Pre-built model names are also converted to lowercase.
+        """
 
         if isinstance(values, dict):
             model = values.get("model")
-
             if isinstance(model, dict):
                 name = model.get("name")
-                model_source = model.get("model_source")
-
-                if isinstance(name, str) and model_source in {"prebuilt", "custom"}:
-                    model["name"] = cls._canonicalise_model_identifier(
-                        name=name,
-                        version=model.pop("version", None),
-                        model_source=model_source,
-                    )
-
+                if isinstance(name, str):
+                    name = name.strip()
+                    if model.get("model_source") == "prebuilt":
+                        name = name.lower()
+                    model["name"] = name
         return values
 
     config_schema_version: str = Field(

--- a/src/ng_model_gym/core/config/custom_template.json
+++ b/src/ng_model_gym/core/config/custom_template.json
@@ -1,5 +1,5 @@
 {
-    "config_schema_version": "9",
+    "config_schema_version": "10",
     "model": {
         "name": "<NAME_OF_REGISTERED_MODEL>",
         "model_source": "custom",

--- a/src/ng_model_gym/core/config/schema_config.json
+++ b/src/ng_model_gym/core/config/schema_config.json
@@ -1,6 +1,6 @@
 {
     "config_schema_version": {
-        "default": "9",
+        "default": "10",
         "description": "Config schema version. Used to check compatibility.",
         "type": "string"
     },

--- a/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
+++ b/src/ng_model_gym/usecases/nfru/configs/nfru_template.json
@@ -1,5 +1,5 @@
 {
-    "config_schema_version": "9",
+    "config_schema_version": "10",
     "model": {
         "name": "NFRU-v1",
         "model_source": "prebuilt",

--- a/src/ng_model_gym/usecases/nss/configs/nss_v1_template.json
+++ b/src/ng_model_gym/usecases/nss/configs/nss_v1_template.json
@@ -1,5 +1,5 @@
 {
-    "config_schema_version": "9",
+    "config_schema_version": "10",
     "model": {
         "name": "NSS-v1",
         "model_source": "prebuilt",

--- a/tests/scripts/test_config.py
+++ b/tests/scripts/test_config.py
@@ -243,7 +243,6 @@ class TestConfig(unittest.TestCase):
         user_config["model"] = {
             "name": "my_model",
             "model_source": "custom",
-            "version": "1",
             "custom_field": 0.1,
         }
 
@@ -254,41 +253,10 @@ class TestConfig(unittest.TestCase):
                 json.dump(user_config, temp_file)
                 temp_path = Path(temp_file.name)
 
-            with self.assertWarnsRegex(DeprecationWarning, "model.version"):
-                loaded = load_config_file(temp_path)
-
-            self.assertEqual(loaded.model.name, "my_model-v1")
+            loaded = load_config_file(temp_path)
+            self.assertEqual(loaded.model.name, "my_model")
             self.assertEqual(loaded.model.model_source, "custom")
             self.assertEqual(loaded.model.custom_field, 0.1)
-
-    def test_legacy_prebuilt_model_version_is_folded_into_name(self):
-        """Test legacy model.version is folded into model.name for prebuilt models."""
-
-        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
-        user_config["model"]["name"] = "NSS"
-        user_config["model"]["version"] = "1"
-
-        with self.assertWarnsRegex(DeprecationWarning, "model.version"):
-            loaded_config = config_model.ConfigModel.model_validate(user_config)
-
-        self.assertEqual(loaded_config.model.name, "nss-v1")
-        self.assertNotIn("version", loaded_config.model.model_dump(mode="json"))
-
-    def test_legacy_model_version_conflict_is_rejected(self):
-        """Test conflicting legacy model.version and versioned model.name is rejected."""
-
-        user_config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
-        user_config["model"]["name"] = "NSS-v1"
-        user_config["model"]["version"] = "2"
-
-        with self.assertWarnsRegex(DeprecationWarning, "model.version"):
-            with self.assertRaises(ValidationError) as exc:
-                config_model.ConfigModel.model_validate(user_config)
-
-        self.assertIn(
-            "model.version conflicts with the version encoded in model.name",
-            str(exc.exception),
-        )
 
     def test_model_specific_config_classes_in_union_type(self):
         """
@@ -327,6 +295,17 @@ class TestConfig(unittest.TestCase):
                 + "\nAdd them to config_model.prebuilt_models_settings union."
             )
             self.fail(message)
+
+    def test_prebuilt_model_rejects_separate_version_field(self):
+        """A prebuilt model identifier must be supplied entirely in model.name."""
+        config = create_simple_params(usecase="nss-v1").model_dump(mode="json")
+        config["model"]["version"] = "1"
+
+        with self.assertRaises(ValidationError) as raised:
+            config_model.ConfigModel.model_validate(config)
+
+        self.assertIn(".version", str(raised.exception))
+        self.assertIn("Extra inputs are not permitted", str(raised.exception))
 
 
 class TestConfigLogging(unittest.TestCase):


### PR DESCRIPTION
* Remove functionality to fold `model.version` into `model.name`
* Providing `model.version` now produces a validation error
* Update tests to match this change
* Bump `CONFIG_SCHEMA_VERSION` to 10
    
Signed-off-by: Ciara Sookarry <ciara.sookarry@arm.com>
Change-Id: I1c5e3df4c44e182c8fc0e3f5cc01510fbd50f9e5
